### PR TITLE
Some setup tweaks: readme, linting and more

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,6 @@
+{
+  "extends": "airbnb-base",
+  "env": {
+    "mocha": true
+  }
+}

--- a/README.md
+++ b/README.md
@@ -323,17 +323,17 @@ Help would most definitely be appreciated!  If you've forked the repo and added 
 
 MIT © Ben Titcomb
 
-[node-img]: https://img.shields.io/node/v/object-flatten-referencing.svg?style=flat-square&label=works%20on%20node
-[node-url]: https://www.npmjs.com/package/object-flatten-referencing
+[node-img]: https://img.shields.io/node/v/skills-in-pills.svg?style=flat-square&label=works%20on%20node
+[node-url]: https://www.npmjs.com/package/skills-in-pills
 
-[npm-img]: https://img.shields.io/npm/v/object-flatten-referencing.svg?style=flat-square&label=release
-[npm-url]: https://www.npmjs.com/package/object-flatten-referencing
+[npm-img]: https://img.shields.io/npm/v/skills-in-pills.svg?style=flat-square&label=release
+[npm-url]: https://www.npmjs.com/package/skills-in-pills
 
 [deps2d-img]: https://img.shields.io/badge/deps%20in%202D-see_here-08f0fd.svg?style=flat-square
-[deps2d-url]: http://npm.anvaka.com/#/view/2d/object-flatten-referencing
+[deps2d-url]: http://npm.anvaka.com/#/view/2d/skills-in-pills
 
-[downloads-img]: https://img.shields.io/npm/dm/object-flatten-referencing.svg?style=flat-square
-[downloads-url]: https://npmcharts.com/compare/object-flatten-referencing
+[downloads-img]: https://img.shields.io/npm/dm/skills-in-pills.svg?style=flat-square
+[downloads-url]: https://npmcharts.com/compare/skills-in-pills
 
-[license-badge]: https://img.shields.io/npm/l/object-flatten-referencing.svg?style=flat-square
-[license]: https://github.com/codsen/object-flatten-referencing/blob/master/license.md
+[license-badge]: https://img.shields.io/npm/l/skills-in-pills.svg?style=flat-square
+[license]: https://github.com/Ravenstine/skills-in-pills/blob/master/license.md

--- a/README.md
+++ b/README.md
@@ -1,13 +1,42 @@
-Skills In Pills
-===============
+# Skills In Pills
 
-A nicer way to write Alexa skills. (WIP)
+> A nicer way to write Alexa skills. (WIP)
+
+[![Minimum Node version required][node-img]][node-url]
+[![Link to npm page][npm-img]][npm-url]
+[![View dependencies as 2D chart][deps2d-img]][deps2d-url]
+[![Downloads/Month][downloads-img]][downloads-url]
+[![MIT License][license-badge]][license]
+
 
 - Rapidly prototype fun & useful skills through human-readable configuration.
 - Easily handle many complex states within a skill.
-- Compile your intent schema from your skill configuration.  Never be baffled at synatx errors in your schema.†
+- Compile your intent schema from your skill configuration.  Never be baffled at syntax errors in your schema.†
 
-**NOTE:** A bunch of things are subject to change, including how the skill fundamentally is run and installed.  For the time being, treat this thing as a toy.
+**NOTE:** A bunch of things is subject to change, including how the skill fundamentally is run and installed.  For the time being, treat this thing as a toy.
+
+## Table of Contents
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+
+- [Structure](#structure)
+- [Getting Started](#getting-started)
+- [Core Concepts](#core-concepts)
+- [Tutorial](#tutorial)
+  - [Skill Setup](#skill-setup)
+  - [Tutorial Cont'd](#tutorial-contd)
+- [Schema Builder](#schema-builder)
+- [Development](#development)
+- [Deployment](#deployment)
+- [Object Reference](#object-reference)
+- [Tests](#tests)
+- [HALP](#halp)
+- [TODO](#todo)
+- [License](#license)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Structure
 
@@ -22,11 +51,11 @@ At the moment, Skills in Pills is available simply as an app skeleton.  Follow t
 
 ## Core Concepts
 
-A skill is configured almost entirely through YAML files referred to as "pills".  If you are familiar with [how to write YAML](https://learnxinyminutes.com/docs/yaml/), then you know how to write a skill with pills.  An entire skill can be represented in a single pill, or multiple pills can be used to represent groups of states(e.g. different "scenes" in a text adventure game).  `entrypoint.yml` is always the default pill.
+A skill is configured almost entirely through YAML files referred to as "pills".  If you are familiar with [how to write YAML](https://learnxinyminutes.com/docs/yaml/), then you know how to write a skill with pills.  An entire skill can be represented in a single pill, or multiple pills can be used to represent groups of states(e.g., different "scenes" in a text adventure game).  `entrypoint.yml` is always the default pill.
 
 Each pill contains one or more "labels", which are merely the top-level objects in a pill.  You can think of them as the equivalent of functions in a programming language, though they are much more constrained than that.  A label can contain a variety of keys & values that build a skill response.
 
-For example, a label can have a `speak:` key that defines the speech text that is returned to an Alexa-enabled device.  If you want to ask the user a question and wait for a response, you would define that with a `ask:`.
+For example, a label can have a `speak:` key that defines the speech text that is returned to an Alexa-enabled device.  If you want to ask the user a question and wait for a response, you will define that with an `ask:`.
 
 ## Tutorial
 
@@ -40,7 +69,7 @@ In `myskill/pills/entrypoint.yml`, you'll see the following:
 
 ```yaml
 Intro:
-  speak: Congratulations!  You've successuflly run your first skill with pills.
+  speak: Congratulations!  You've successfully run your first skill with pills.
 ```
 
 Before we continue, build your schema by running `skill-in-pills build-schema`.  This will write a JSON file to the `schemas/` directory.
@@ -51,7 +80,7 @@ Now it's time to run the Bespoken Tools proxy server:
 bst proxy lambda index.js --verbose
 ```
 
-The output of that command will say something like `Your URL for Alexa Skill configuration:` and a link.  Copy that link down for later.
+The output of that command will say something like `Your URL for Alexa Skill configuration:` and a link.  Copy down that link for later.
 
 ### Skill Setup
 
@@ -76,7 +105,7 @@ Bespoken Tools is a useful tool that allows you to develop Alexa skills locally,
 
 The skill can be invoked by saying "Alexa, open my skill."
 
-Your device will then respond with "Congratulations!  You've successuflly run your first skill with pills."
+Your device will then respond with "Congratulations!  You've successfully run your first skill with pills."
 
 If that's the response you get, then you're good to go.  This is a pretty boring skill, though.  Let's make something more interesting!
 
@@ -97,7 +126,7 @@ Intro:
   ask: What's your favorite animal?
 ```
 
-Upon reinvoking the skill, you'll notice that the Echo device will wait for a response, but does nothing more even if you respond to it.  Let's actually make it listen to what you have to say by adding an intent.
+Upon reinvoking the skill, you'll notice that the Echo device will wait for a response, but does nothing more even if you respond to it.  Let's make it listen to what you have to say by adding an intent.
 
 ```yaml
 # pills/entrypoint.yml
@@ -110,7 +139,7 @@ Intro:
       go to: Read Animal Fact
 ```
 
-Hmm... that's not how you write an intent name... is it?  That looks more like a sample utterance.  Anyway, moving on.
+Hmm... that's not how you write an intent name, is it?  That looks more like a sample utterance.  Anyway, moving on.
 
 Because we have now changed how the interaction model works, we have to generate a new intent schema by running `skill-in-pills build-schema`.  Let's check out what's in that new file.
 
@@ -152,7 +181,7 @@ Because we have now changed how the interaction model works, we have to generate
 
 How did it do that???
 
-The compiler looked at the utterance you wrote and derived an intent name, a sample utterance, an a slot including the slot type!  When you define a slot in your intent by itself with no type specified, it will attempt to guess the type based on the name if it matches an Amazon built-in slot type.  We'll learn about defining types later on.  For now, this will work perfectly.
+The compiler looked at the utterance you wrote and derived an intent name, a sample utterance and a slot including the slot type!  When you define a slot in your intent by itself with no type specified, it will attempt to guess the type based on the name if it matches an Amazon built-in slot type.  We'll learn about defining types later on.  For now, this will work perfectly.
 
 Upload this schema in the Skill Builder and build the interaction model.  When that's done, reinvoke your skill by saying "Alexa, open my skill."
 
@@ -172,7 +201,7 @@ Read Animal Fact:
   speak: You said ${animal}.
 ```
 
-Now if you tell it that you like crocodiles, it will say "You like crocodiles."  How... useless.  Let's make your skill useful!
+Now if you tell it that you like crocodiles, it will say "You like crocodiles."  How useless!  Let's make your skill useful!
 
 ```yaml
 # pills/entrypoint.yml
@@ -185,13 +214,13 @@ Intro:
       go to: Read Animal Fact
 
 Read Animal Fact:
-  web request: 
+  web request:
     url: https://simple.wikipedia.org/w/api.php?format=json&redirects=1&action=query&prop=extracts&exintro=&explaintext=&titles=${animal}
     pluck: extract
   speak: You said ${animal}. ${webResponse}.
 ```
 
-Incredible!  You've written a skill that takes user input and returns useful information!  A skill can really be this simple.  But there are some finishing touches we should add.
+Incredible!  You've written a skill that takes user input and returns useful information!  A skill can be this simple.  But there are some finishing touches we should add.
 
 ```yaml
 # pills/entrypoint.yml
@@ -217,9 +246,9 @@ Read Animal Fact:
   speak: You said ${animal}. ${webResponse}.
 ```
 
-Since we want a user to also be able to invoke the skill by saying "Alexa, ask my skill about monkeys", we've added a new label at the top of the pill that directs us between the intro and the fact reader.  The label at the top of a pill is always the first to be executed during a session.  You can think of what we created as a "router" label.
+Since we want a user also to be able to invoke the skill by saying "Alexa, ask my skill about monkeys", we've added a new label at the top of the pill that directs us between the intro and the fact reader.  The label at the top of a pill is always the first to be executed during a session.  You can think of what we created as a "router" label.
 
-Sometimes you'll ask it something it will not know about.  In that case, the `none speak:` key in the web request overrides the label dialog if the search result returned nothing.
+Sometimes you'll ask it something that it does not know.  In that case, the `none speak:` key in the web request overrides the label dialog if the search result returned nothing.
 
 ## Schema Builder
 
@@ -253,7 +282,7 @@ Run tests with the `mocha` command in the root project folder.
 
 ## HALP
 
-Help would most definitely be appreciated!  If you've forked the repo and added your own features, don't hesitate to make a pull request.  Assistance with documentation, as well as discussion in [issues](https://github.com/ravenstine/skills-in-pills/issues) would be of great help.
+Help would most definitely be appreciated!  If you've forked the repo and added new features, don't hesitate to make a pull request.  Assistance with documentation, as well as discussion in [issues](https://github.com/ravenstine/skills-in-pills/issues) would be of great help.
 
 ## TODO
 
@@ -292,5 +321,19 @@ Help would most definitely be appreciated!  If you've forked the repo and added 
 
 ## License
 
-See [LICENSE.txt](https://github.com/Ravenstine/skills-in-pills/blob/master/LICENSE.txt).
+MIT © Ben Titcomb
 
+[node-img]: https://img.shields.io/node/v/object-flatten-referencing.svg?style=flat-square&label=works%20on%20node
+[node-url]: https://www.npmjs.com/package/object-flatten-referencing
+
+[npm-img]: https://img.shields.io/npm/v/object-flatten-referencing.svg?style=flat-square&label=release
+[npm-url]: https://www.npmjs.com/package/object-flatten-referencing
+
+[deps2d-img]: https://img.shields.io/badge/deps%20in%202D-see_here-08f0fd.svg?style=flat-square
+[deps2d-url]: http://npm.anvaka.com/#/view/2d/object-flatten-referencing
+
+[downloads-img]: https://img.shields.io/npm/dm/object-flatten-referencing.svg?style=flat-square
+[downloads-url]: https://npmcharts.com/compare/object-flatten-referencing
+
+[license-badge]: https://img.shields.io/npm/l/object-flatten-referencing.svg?style=flat-square
+[license]: https://github.com/codsen/object-flatten-referencing/blob/master/license.md

--- a/index.js
+++ b/index.js
@@ -1,8 +1,4 @@
-'use strict';
+const pillBox = require('./lib/pill-box');
+const handler = require('./lib/handler');
 
-const pillBox   = require('./lib/pill-box');
-
-module.exports  = (pillsDirectory) => {
-  return require('./lib/handler')(pillBox(pillsDirectory));
-}
-
+module.exports = pillsDirectory => (handler)(pillBox(pillsDirectory));

--- a/lib/builders/assign.js
+++ b/lib/builders/assign.js
@@ -1,124 +1,124 @@
-'use strict';
+/* eslint no-param-reassign:0 */
 
 const coffeeEval = require('../coffee-eval');
 const evalString = require('../eval-string');
-const chrono     = require('chrono-node');
+const chrono = require('chrono-node');
 
 // note that this is used for both `assign:` and `temp:`, and possibly more things in the future.
 
 const operations = {
-  set(k, v, assignee, context){
-    if(typeof v === 'string'){
+  set(k, v, assignee, context) {
+    if (typeof v === 'string') {
       assignee[k] = evalString(v, context);
     } else {
       assignee[k] = v;
     }
   },
-  increment(k, v, assignee, context){
-    let initialValue = assignee[k];
-    if(!initialValue){
+  increment(k, v, assignee) {
+    const initialValue = assignee[k];
+    if (!initialValue) {
       // if there is no initial value, just assign
       // the incremental value we were given
       assignee[k] = v;
     } else if (typeof initialValue === 'number' || typeof initialValue === 'string') {
-      let parsedInitial = parseFloat(initialValue);
-      let parsedValue   = parseFloat(v);
-      if(parsedInitial !== NaN && parsedValue !== NaN){
+      const parsedInitial = parseFloat(initialValue);
+      const parsedValue = parseFloat(v);
+      if (!Number.isNaN(parsedInitial) && !Number.isNaN(parsedValue)) {
         assignee[k] = parsedInitial + parsedValue;
       }
     }
   },
-  erase(k, v, assignee, context) {
+  erase(k, v, assignee) {
     delete assignee[k];
   },
-  append(k, v, assignee, context) {
-    let initialValue = assignee[k];
-    if(!initialValue) {
+  append(k, v, assignee) {
+    const initialValue = assignee[k];
+    if (!initialValue) {
       // pretend like nothing's wrong and just
       // assign the current value
       assignee[k] = v;
     } else if (Array.isArray(initialValue)) {
       assignee[k].push(v);
     } else if (typeof initialValue === 'string') {
-      if(typeof v !== 'object' && typeof v !== void(0)){
+      if (typeof v !== 'object' && v !== undefined) {
         // objects would just append weirdly to strings
         // so we're just never going to do it
         assignee[k] += v;
       }
-    } else if ((typeof initialValue === 'number') && (typeof v !== 'object') && (typeof v !== void(0))) {
+    } else if ((typeof initialValue === 'number') && (typeof v !== 'object') && (v !== undefined)) {
       assignee[k] = `${initialValue}${v}`;
     }
   },
   prepend(k, v, assignee, context) {
     // sort of the reverse of what happens in #append
-    let initialValue = assignee[k];
-    if(!initialValue) {
+    const initialValue = assignee[k];
+    if (!initialValue) {
       assignee[k] = v;
     } else if (Array.isArray(initialValue)) {
       assignee[k].unshift(v);
     } else if (typeof initialValue === 'string') {
-      if(typeof v !== 'object' && typeof v !== void(0)){
+      if (typeof v !== 'object' && v !== undefined) {
         // objects would just append weirdly to strings
         // so we're just never going to do it
         assignee[k] = evalString(v, context) + assignee[k];
       }
-    } else if ((typeof initialValue === 'number') && (typeof v !== 'object') && (typeof v !== void(0))) {
+    } else if ((typeof initialValue === 'number') && (typeof v !== 'object') && (v !== undefined)) {
       assignee[k] = `${v}${initialValue}`;
     }
   },
-  multiply(k, v, assignee, context) {
-    let initialValue = parseFloat(assignee[k]);
-    let newValue     = parseFloat(v);
-    if((initialValue !== NaN) && (newValue !== NaN)){
+  multiply(k, v, assignee) {
+    const initialValue = parseFloat(assignee[k]);
+    const newValue = parseFloat(v);
+    if (!Number.isNaN(initialValue) && !Number.isNaN(newValue)) {
       assignee[k] = initialValue * newValue;
     }
   },
-  min(k, v, assignee, context) {
-    let initialValue = parseFloat(assignee[k]);
-    if(initialValue < v){
+  min(k, v, assignee) {
+    const initialValue = parseFloat(assignee[k]);
+    if (initialValue < v) {
       assignee[k] = v;
     }
   },
-  max(k, v, assignee, context) {
-    let initialValue = parseFloat(assignee[k]);
-    if(initialValue > v){
+  max(k, v, assignee) {
+    const initialValue = parseFloat(assignee[k]);
+    if (initialValue > v) {
       assignee[k] = v;
     }
   },
   date(k, v, assignee, context) {
     // currently the safest way to add dates to attributes
-    if(Object.prototype.toString.call(v) === '[object Date]'){
+    if (Object.prototype.toString.call(v) === '[object Date]') {
       assignee[k] = v;
     } else if ((typeof v === 'string') || (typeof v === 'number')) {
       // human date string parsing! 😮
-      let parsedDate = chrono.parseDate(evalString(v, context));
-      if(parsedDate){
+      const parsedDate = chrono.parseDate(evalString(v, context));
+      if (parsedDate) {
         assignee[k] = parsedDate;
       }
     }
   },
   expression(k, v, assignee, context) {
     // assign the result of a CoffeeScript
-    let tempContext = {x: assignee[k]};
+    const tempContext = { x: assignee[k] };
     Object.assign(tempContext, context);
-    if(typeof v === 'string'){
+    if (typeof v === 'string') {
       assignee[k] = coffeeEval(v, tempContext);
     }
   },
   slot(k, v, assignee, context) {
     // if the context has a slot from an intent,
     // store the slot value as a session attribute
-    let slotValue = context.slots[v];
-    if(slotValue){
+    const slotValue = context.slots[v];
+    if (slotValue) {
       assignee[k] = slotValue;
     }
-  }
+  },
 };
 
-function performOperations(assignee, assigner, context){
+function performOperations(assignee, assigner, context) {
   Object.keys(assigner).forEach((opName) => {
     Object.keys(assigner[opName]).forEach((k) => {
-      let v = assigner[opName][k];
+      const v = assigner[opName][k];
       operations[opName](k, v, assignee, context);
     });
   });
@@ -127,11 +127,10 @@ function performOperations(assignee, assigner, context){
 module.exports = (assignee, assignments, context) => {
   // `assign:` can either be a singular operation object
   // or an array of multiple operation objects
-  if(!assignments){ return; }
-  if(Array.isArray(assignments)){
+  if (!assignments) { return; }
+  if (Array.isArray(assignments)) {
     assignments.forEach(op => performOperations(assignee, op, context));
   } else if (typeof assignments === 'object') {
     performOperations(assignee, assignments, context);
   }
-}
-
+};

--- a/lib/bundle-blueprint.js
+++ b/lib/bundle-blueprint.js
@@ -1,4 +1,3 @@
-const handler   = require('./handler');
+const handler = require('./handler');
 
 exports.handler = handler(pills);
-

--- a/lib/coffee-eval.js
+++ b/lib/coffee-eval.js
@@ -1,15 +1,15 @@
-'use strict';
+/* eslint new-cap:0, no-console:0 */
 
 const CoffeeScript = require('coffeescript');
-const vm           = require('vm');
-const _            = require('lodash');
+const vm = require('vm');
+const _ = require('lodash');
 
 module.exports = (coffeeSource, context, scope) => {
-  if(!coffeeSource){ return; }
-  let src     = CoffeeScript.compile(coffeeSource, {bare: true});
-  let script  = new vm.Script(src)
+  if (!coffeeSource) { return; }
+  const src = CoffeeScript.compile(coffeeSource, { bare: true });
+  const script = new vm.Script(src);
 
-  let ctx = {_: _};
+  const ctx = { _ };
 
   Object.assign(ctx, context);
   Object.assign(ctx, context.webResponse || {});
@@ -17,18 +17,15 @@ module.exports = (coffeeSource, context, scope) => {
   Object.assign(ctx, context.temp);
   Object.assign(ctx, context.slots);
 
-  if(scope){
+  if (scope) {
     Object.assign(ctx, scope);
   }
 
-  let vmContext = new vm.createContext(ctx);
+  const vmContext = new vm.createContext(ctx);
 
   try {
     return script.runInNewContext(vmContext);
-  } catch(err) {
+  } catch (err) {
     console.warn(err);
-    return;
   }
-
-}
-
+};

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -1,4 +1,4 @@
-'use strict';
+/* eslint no-param-reassign:0 */
 
 // This opens every pill, finds all the intent information, and merges it all
 // into an intent-schema JSON that you can paste into the code editor
@@ -7,32 +7,63 @@
 const utteranceExpander = require('intent-utterance-expander');
 
 module.exports = (pillBox) => {
-
   // Each of the three AMAZON intents below are required.
-  let intents   = {
-    "AMAZON.CancelIntent": {
-      "name": "AMAZON.CancelIntent",
-      "samples": []
+  const intents = {
+    'AMAZON.CancelIntent': {
+      name: 'AMAZON.CancelIntent',
+      samples: [],
     },
-    "AMAZON.HelpIntent": {
-      "name": "AMAZON.HelpIntent",
-      "samples": []
+    'AMAZON.HelpIntent': {
+      name: 'AMAZON.HelpIntent',
+      samples: [],
     },
-    "AMAZON.StopIntent": {
-      "name": "AMAZON.StopIntent",
-      "samples": []
-    }
+    'AMAZON.StopIntent': {
+      name: 'AMAZON.StopIntent',
+      samples: [],
+    },
   };
 
-  let types     = {};
+  const types = {};
 
-  function extractIntents(currentIntents){
+  function mergeSlots(a, b) {
+    if (!a || !b) { return; }
+    // go through each slot from the current
+    // intent object(which is b) and try to
+    // merge it into the intent of the corresponding
+    // name in the main intents object
+    Object.keys(b).forEach((slotName) => {
+      const aSlot = a[slotName];
+      const bSlot = b[slotName];
+      if (!aSlot) {
+        // if the merged intent slot doesn't exist,
+        // just assign a clone of the current slot
+        a[slotName] = Object.assign({}, bSlot);
+      } else if (
+        (!aSlot.type || (aSlot.type || '').match(/^AMAZON\./)) &&
+        !(bSlot.type || '').match(/^AMAZON\./)
+      ) {
+        // only re-assign the slot type on the merged
+        // slot if there is no type defined to begin
+        // with, or if the new assignment is a custom
+        // slot type.  not sure why i made that decision
+        // but that's how it works right now so there.
+        aSlot.type = bSlot.type;
+        if (aSlot.type) {
+          aSlot.values = (aSlot.values || []).concat(bSlot.values || []);
+        }
+      } else {
+        aSlot.values = (aSlot.values || []).concat(bSlot.values || []);
+      }
+    });
+  }
+
+  function extractIntents(currentIntents) {
     // expects an intents object, usually from a choice.
     //
     // goes through each intent, does some processing,
     // and merges into the main intents object
     Object.keys(currentIntents).forEach((intentName) => {
-      if(!intentName || intentName.trim() === '?') {
+      if (!intentName || intentName.trim() === '?') {
         // ignore wildcard intent fields
         return;
       }
@@ -40,17 +71,17 @@ module.exports = (pillBox) => {
       intents[intentName] = intents[intentName] || {
         name: intentName,
         samples: [],
-        slots: {}
+        slots: {},
       };
 
-      let currentIntent   = currentIntents[intentName];
+      const currentIntent = currentIntents[intentName];
 
-      let mergedIntent    = intents[intentName];
+      const mergedIntent = intents[intentName];
 
-      let currentSamples  = currentIntent.samples || [];
+      const currentSamples = currentIntent.samples || [];
 
       // expand out the sample utterances
-      let expandedSamples = utteranceExpander(currentSamples);
+      const expandedSamples = utteranceExpander(currentSamples);
       // merge the expaned samples into the merged intent samples
       mergedIntent.samples = mergedIntent.samples.concat.apply([], expandedSamples);
       // uniq the samples array
@@ -64,36 +95,6 @@ module.exports = (pillBox) => {
       // note that this has nothing to do with the
       // final compilation of types.
       // mergeTypes(mergedIntent.slots);
-
-    });
-  }
-
-  function mergeSlots(a, b){
-    if(!a || !b){ return; }
-    // go through each slot from the current
-    // intent object(which is b) and try to
-    // merge it into the intent of the corresponding
-    // name in the main intents object
-    Object.keys(b).forEach((slotName) => {
-      let aSlot = a[slotName];
-      let bSlot = b[slotName];
-      if(!aSlot){
-        // if the merged intent slot doesn't exist,
-        // just assign a clone of the current slot
-        a[slotName] = Object.assign({}, bSlot);
-      } else if(!aSlot.type || (aSlot.type || '').match(/^AMAZON\./) && !(bSlot.type || '').match(/^AMAZON\./)) {
-        // only re-assign the slot type on the merged
-        // slot if there is no type defined to begin
-        // with, or if the new assignment is a custom
-        // slot type.  not sure why i made that decision
-        // but that's how it works right now so there.
-        aSlot.type = bSlot.type;
-        if(aSlot.type){
-          aSlot.values = (aSlot.values || []).concat(bSlot.values || []);
-        }
-      } else {
-        aSlot.values = (aSlot.values || []).concat(bSlot.values || []);
-      }
     });
   }
 
@@ -103,49 +104,48 @@ module.exports = (pillBox) => {
 
   // open each pill,
   // find & merge all intents into a main intents object,
-  // 
+  //
   Object.keys(pillBox).forEach((key) => {
-    let pill = pillBox[key];
+    const pill = pillBox[key];
     // go through each label of the pill
     Object.keys(pill).forEach((labelName) => {
-      let label = pill[labelName];
+      const label = pill[labelName];
       extractIntents(label.intents || {});
     });
-  })
+  });
 
   // go through each intent and
   // extract slot type information
   Object.keys(intents).forEach((intentName) => {
-    let intent = intents[intentName];
+    const intent = intents[intentName];
     Object.keys(intent.slots || []).forEach((slotName) => {
-      let slot = intent.slots[slotName];
-      if(slot.type){
+      const slot = intent.slots[slotName];
+      if (slot.type) {
         // create a key in global types object so we
         // can merge unique types
         types[slot.type] = types[slot.type] || {};
-        let type = types[slot.type];
+        const type = types[slot.type];
         type.values = (type.values || []).concat(slot.values || []);
         type.values = Array.from(new Set(type.values)); // uniq the values
         type.values = type.values.map((v) => {
           // transform string values
           // into proper slot value objects
-          if(typeof v === 'string'){
+          if (typeof v === 'string') {
             return {
               id: null,
               name: {
                 value: v,
-                synonyms: []
-              }
-            };
-          } else {
-            return {
-              id: null,
-              name: {
-                value: v.value,
-                synonyms: v.synonyms || []
-              }
+                synonyms: [],
+              },
             };
           }
+          return {
+            id: null,
+            name: {
+              value: v.value,
+              synonyms: v.synonyms || [],
+            },
+          };
         });
       }
     });
@@ -155,26 +155,25 @@ module.exports = (pillBox) => {
 
   return {
     intents: Object.keys(intents).map((name) => {
-      if(!name.match(/Intent$/)){
+      if (!name.match(/Intent$/)) {
         // if the intent is actually a 'virtual' request(e.g. LaunchRequest)
         // then don't include it when compiling
         return;
       }
-      let intent   = Object.assign({}, intents[name]);
-      intent.slots = Object.keys(intent.slots || {}).map((slotName) => { 
-        return { name: slotName, type: intent.slots[slotName].type, samples: [] }; 
-      });
+      const intent = Object.assign({}, intents[name]);
+      intent.slots = Object.keys(intent.slots || {})
+        .map(slotName => ({ name: slotName, type: intent.slots[slotName].type, samples: [] }));
       return intent;
     }).filter(a => a),
     types: Object.keys(types).map((name) => {
       // go through each of our compiled intents,
       // look through the slots, and extract/merge
       // the types that are specified
-      if(name.match(/^AMAZON\./)){return;}
-      let type = types[name];
+      if (name.match(/^AMAZON\./)) { return; }
+      const type = types[name];
       return {
-        name: name,
-        values: (type.values || [])
+        name,
+        values: (type.values || []),
       };
     }).filter(a => a),
     // dialog: {
@@ -182,6 +181,4 @@ module.exports = (pillBox) => {
     //   ask: {}
     // }
   };
-
-}
-
+};

--- a/lib/context-generator.js
+++ b/lib/context-generator.js
@@ -1,49 +1,48 @@
-'use strict';
+/* eslint no-param-reassign:0 */
 
 const Navigator = require('./navigator');
 const SlotValue = require('./slot-value');
 
 module.exports = (request, pills) => {
-  request  = Object.assign({
+  request = Object.assign({
     request: {},
-    session: {}
+    session: {},
   }, request || {});
 
-  let response = {
-    version: "1.0",
+  const response = {
+    version: '1.0',
     sessionAttributes: Object.assign({
       PILL: 'entrypoint',
-      ATTRIBUTES: {}
+      ATTRIBUTES: {},
     }, ((request.session || {}).attributes || {})),
     response: {
-      shouldEndSession: true
-    }
-  }
+      shouldEndSession: true,
+    },
+  };
 
   pills = pills || {};
 
-  let context = {
-    request: request,
+  const context = {
+    request,
     requestBody: request.request,
-    response: response,
+    response,
     responseBody: response.response,
     attributes: response.sessionAttributes.ATTRIBUTES,
     session: request.session,
     sessionAttributes: response.sessionAttributes,
     slots: {},
-    temp: {}
+    temp: {},
   };
   context.navigator = new Navigator(pills, context);
 
   // If there are slots in the request, let's make a
   // nice little slots object to add to our context.
-  if(request && request.request && request.request.type == "IntentRequest"){
-    let intentSlots = (((request.request || {}).intent || {}).slots || {});
+  if (request && request.request && request.request.type === 'IntentRequest') {
+    const intentSlots = (((request.request || {}).intent || {}).slots || {});
     Object.keys(intentSlots).forEach((slotName) => {
       context.slots[slotName] = new SlotValue(intentSlots[slotName]);
     });
   }
 
   return context;
-}
-
+};

--- a/lib/dealer.js
+++ b/lib/dealer.js
@@ -1,58 +1,54 @@
-'use strict';
+
 
 const generateContext = require('./context-generator');
-const swallowPill     = require('./pill-swallower');
-const intents         = require('./builders/intents');
-const _events         = require('./builders/events');
+const swallowPill = require('./pill-swallower');
+const intents = require('./builders/intents');
+const _events = require('./builders/events');
 
 // Basically the 'run loop' of the skill.
 
-module.exports = (request, pills) => {
-  return new Promise((resolve, reject) => {
-    
-    let context = generateContext(request, pills);
+module.exports = (request, pills) => new Promise((resolve, reject) => {
+  const context = generateContext(request, pills);
 
-    let currentLabel  = context.navigator.currentLabel;
-    
-    // If we've been waiting for a user response, and we
-    // have received one, continue the deferred conditionals
-    // in the label.
-    if(context.navigator.hasFinishedWaiting){
-      _events(currentLabel.events, context);
-      intents(currentLabel.intents, context);
-      if(!context.navigator.hasNavigated){
-        if(context.navigator.willNavigate){
-          context.navigator.navigate(currentLabel);
-        }
-        if(!context.navigator.hasNavigated){
-          // If no navigation occurred after waiting, 
-          // and the label itself won't navigate,
-          // there's nowhere else to go, so exit the app.
-          return resolve(context);
-        }
+  const currentLabel = context.navigator.currentLabel;
+
+  // If we've been waiting for a user response, and we
+  // have received one, continue the deferred conditionals
+  // in the label.
+  if (context.navigator.hasFinishedWaiting) {
+    _events(currentLabel.events, context);
+    intents(currentLabel.intents, context);
+    if (!context.navigator.hasNavigated) {
+      if (context.navigator.willNavigate) {
+        context.navigator.navigate(currentLabel);
+      }
+      if (!context.navigator.hasNavigated) {
+        // If no navigation occurred after waiting,
+        // and the label itself won't navigate,
+        // there's nowhere else to go, so exit the app.
+        return resolve(context);
       }
     }
+  }
 
-    context.navigator.stopWaiting();
-    context.navigator.reload();
-    
-    function takeAPill(){
-      swallowPill(context.navigator.currentPill, context)
-        .then(() => {
-          if(context.navigator.hasNavigated && !context.navigator.isWaiting){
-            context.navigator.reload();
-            takeAPill();
-          } else {
-            resolve(context);
-          }
-        })
-        .catch((err) => {
-          reject(err);
-        });
-    }
+  context.navigator.stopWaiting();
+  context.navigator.reload();
 
-    takeAPill();
+  function takeAPill() {
+    swallowPill(context.navigator.currentPill, context)
+      .then(() => {
+        if (context.navigator.hasNavigated && !context.navigator.isWaiting) {
+          context.navigator.reload();
+          takeAPill();
+        } else {
+          resolve(context);
+        }
+      })
+      .catch((err) => {
+        reject(err);
+      });
+  }
 
-  });
-}
+  takeAPill();
+});
 

--- a/lib/eval-string.js
+++ b/lib/eval-string.js
@@ -1,41 +1,40 @@
-'use strict';
+
 
 const coffeeEval = require('./coffee-eval');
 const moment = require('moment');
 // require('moment/locale/de');
 
-const Entities    = require('html-entities').AllHtmlEntities;
-const entities    = new Entities();
+const Entities = require('html-entities').AllHtmlEntities;
+
+const entities = new Entities();
 
 module.exports = (string, context, options) => {
-  if(!string) {return '';}
+  if (!string) { return ''; }
   // parses es2015-style template strings
   return string.replace(/\$\{([^\\}]*(?:\\.[^\\}]*)*)\}/g, (match, p1) => {
-    let value = coffeeEval(p1, context);
+    const value = coffeeEval(p1, context);
     let result = '';
-    if(value == void(0) || value === NaN){
+    if (value === undefined || Number.isNaN(value)) {
       return '';
     } else if (Object.prototype.toString.call(value) === '[object Date]') {
       result = moment(value).format('h m a [on] MMMM D YYYY');
+    } else if (typeof value === 'string') {
+    // we're going to assume that encoded entities
+    // are of no value in an alexa skill.
+    //
+    // this is the best place to decode because
+    // variables besides the web response may
+    // also contain entities.
+      result = entities.decode(value);
     } else {
-      // we're going to assume that encoded entities 
-      // are of no value in an alexa skill.
-      //
-      // this is the best place to decode because
-      // variables besides the web response may
-      // also contain entities.
-      if(typeof value === 'string'){
-        result = entities.decode(value);
-      } else {
-        result = value;
-      }
+      result = value;
     }
-    if(options && options.uriEncode){
+
+    if (options && options.uriEncode) {
       // needed for web requests where the
       // url needs to be string interpolated
       result = encodeURIComponent(result);
     }
     return result;
   });
-}
-
+};

--- a/lib/eval-string.js
+++ b/lib/eval-string.js
@@ -1,5 +1,3 @@
-
-
 const coffeeEval = require('./coffee-eval');
 const moment = require('moment');
 // require('moment/locale/de');

--- a/lib/expand-utterance.js
+++ b/lib/expand-utterance.js
@@ -1,12 +1,10 @@
-'use strict';
+/* eslint no-param-reassign:0, prefer-destructuring:0 */
 
 const utteranceExpander = require('intent-utterance-expander');
-const camelize          = require('camelize');
-const typeAliases       = require('../built-in-slot-type-aliases');
-
+// const camelize = require('camelize');
+const typeAliases = require('../built-in-slot-type-aliases');
 
 module.exports = (utterance, utteranceConfig) => {
-
   let expander;
 
   utteranceConfig.types = utteranceConfig.types || {};
@@ -14,12 +12,12 @@ module.exports = (utterance, utteranceConfig) => {
 
   // parse and replace each of our custom slot tokens
 
-  expander = utterance.replace(/\$\{([A-z]+)\:([A-z|\.]+)\}/g, (token) => {
-    let parsedMatcher = token.match(/\$\{([A-z]+)\:([A-z|\.]+)\}/), slotName, slotType;
-    slotName = parsedMatcher[1];
-    slotType = parsedMatcher[2];
-    utteranceConfig.slots[slotName]        = utteranceConfig.slots[slotName]        || {};
-    utteranceConfig.slots[slotName].type   = utteranceConfig.slots[slotName].type   || slotType;
+  expander = utterance.replace(/\$\{([A-z]+):([A-z|.]+)\}/g, (token) => {
+    const parsedMatcher = token.match(/\$\{([A-z]+):([A-z|.]+)\}/);
+    const slotName = parsedMatcher[1];
+    const slotType = parsedMatcher[2];
+    utteranceConfig.slots[slotName] = utteranceConfig.slots[slotName] || {};
+    utteranceConfig.slots[slotName].type = utteranceConfig.slots[slotName].type || slotType;
     utteranceConfig.slots[slotName].values = utteranceConfig.slots[slotName].values || [];
     return `{${slotName}}`;
   });
@@ -28,18 +26,16 @@ module.exports = (utterance, utteranceConfig) => {
   // if they happen to match the name of an AMAZON built-in slot type,
   // we then assume it's of that type.  otherwise, we create a blank type.
   expander = expander.replace(/\$\{\s*([A-z]+)\s*\}/g, (token) => {
-    let slotName    = token.match(/\$\{\s*([A-z]+)\s*\}/)[1];
-    let guessedType = typeAliases[slotName] || (utteranceConfig.slots[slotName] || {type: 'AMAZON.LITERAL'}).type;
-    if(guessedType){
-      utteranceConfig.slots[slotName]        = utteranceConfig.slots[slotName]        || {};
-      utteranceConfig.slots[slotName].type   = utteranceConfig.slots[slotName].type   || guessedType;
+    const slotName = token.match(/\$\{\s*([A-z]+)\s*\}/)[1];
+    const guessedType = typeAliases[slotName] || (utteranceConfig.slots[slotName] || { type: 'AMAZON.LITERAL' }).type;
+    if (guessedType) {
+      utteranceConfig.slots[slotName] = utteranceConfig.slots[slotName] || {};
+      utteranceConfig.slots[slotName].type = utteranceConfig.slots[slotName].type || guessedType;
       utteranceConfig.slots[slotName].values = utteranceConfig.slots[slotName].values || [];
       return `{${slotName}}`;
-    } else {
-      return '';
     }
+    return '';
   });
 
   utteranceConfig.samples = (utteranceConfig.samples || []).concat(utteranceExpander(expander));
-}
-
+};

--- a/lib/handler.js
+++ b/lib/handler.js
@@ -1,31 +1,25 @@
-'use strict';
+/* eslint no-console:0 */
 
-const remember     = require('./remember');
-const persist      = require('./persist');
-const dealer       = require('./dealer');
+const remember = require('./remember');
+const persist = require('./persist');
+const dealer = require('./dealer');
 
 
-module.exports = (pills) => {
-
-  return (request, ctx, callback) => {
-    // we default to the entrypoint pill if no pill is specified in the request
-    remember(request)
+module.exports = pills => (request, ctx, callback) => {
+  // we default to the entrypoint pill if no pill is specified in the request
+  remember(request)
     .then(() => dealer(request, pills))
-    .then((context) => {
+    .then(context =>
       // Post processing
-      return persist(context)
-        .then(() => callback(null, context.response));
-    })
+      persist(context)
+        .then(() => callback(null, context.response)))
     .catch((err) => {
       // something went very wrong
       console.error(err ? err.stack : err);
-      let dialog = err.speak || label['error dialog'] || "Looks like I overdosed!";
+      const dialog = err.speak || label['error dialog'] || 'Looks like I overdosed!';
       speak(dialog, context);
       context.navigator.goTo(null); // abort!
       context.navigator.reload(); // act like nothin's happened
       callback(err);
     });
-
-  };
-}
-
+};

--- a/lib/label-peeler.js
+++ b/lib/label-peeler.js
@@ -1,90 +1,85 @@
-'use strict';
+
 
 const coffeeEval = require('./coffee-eval');
 const evalString = require('./eval-string');
-const speak      = require('./builders/speak');
-const reprompt   = require('./builders/reprompt');
-const audio      = require('./builders/audio');
+const speak = require('./builders/speak');
+const reprompt = require('./builders/reprompt');
+const audio = require('./builders/audio');
 const webRequest = require('./builders/web-request');
-const intents    = require('./builders/intents');
-const _events    = require('./builders/events');
-const assign     = require('./builders/assign');
-const condition  = require('./builders/condition');
-const card       = require('./builders/card');
-const restore    = require('./builders/restore');
+const intents = require('./builders/intents');
+const _events = require('./builders/events');
+const assign = require('./builders/assign');
+const condition = require('./builders/condition');
+const card = require('./builders/card');
+const restore = require('./builders/restore');
 
 module.exports = (label, context) => {
-  if(!label){ return Promise.resolve(); }
+  if (!label) { return Promise.resolve(); }
   // restore:
   restore(label.restore, context);
 
   // web request:
   return webRequest(label['web request'], context).then(() => {
+    try {
+      // script:
+      coffeeEval(label.script, context);
 
-  try {
+      // temp:
+      assign(context.temp, label.temp, context);
 
-  // script:
-  coffeeEval(label.script, context);
+      // assign:
+      assign(context.attributes, label.assign, context);
 
-  // temp:
-  assign(context.temp, label.temp, context);
+      // speak:
+      speak(label.speak, context);
 
-  // assign:
-  assign(context.attributes, label.assign, context);
+      // audio:
+      audio(label.audio, context);
 
-  // speak:
-  speak(label.speak, context);
+      // card:
+      card(label.card, context);
 
-  // audio:
-  audio(label.audio, context);
+      // ask:
+      // if the label has a choice defined and we haven't
+      // already used go to outside of the choice
+      if (label.hasOwnProperty('ask')) {
+        speak(label.ask, context);
+        const repromptValue = label.reprompt || label.ask;
+        reprompt(repromptValue, context);
+        // 👆 the default reprompt is the choice dialog, unless
+        // `reprompt: ` is specified or cleared when `reprompt: false`
+        // context.responseBody.shouldEndSession = false;
+        context.navigator.wait();
+        // if we are asking a question, we don't want to
+        // continue on to react to the utterances set in
+        // the label.  that should only happen in the next
+        // request when the question is answered.
+        return Promise.resolve();
+      }
 
-  // card:
-  card(label.card, context);
-  
-  // ask:
-  // if the label has a choice defined and we haven't
-  // already used go to outside of the choice
-  if(label.hasOwnProperty('ask')){
-    speak(label.ask, context);
-    let repromptValue = label.reprompt || label.ask;
-    reprompt(repromptValue, context);
-    // 👆 the default reprompt is the choice dialog, unless
-    // `reprompt: ` is specified or cleared when `reprompt: false`
-    // context.responseBody.shouldEndSession = false;
-    context.navigator.wait();
-    // if we are asking a question, we don't want to
-    // continue on to react to the utterances set in
-    // the label.  that should only happen in the next
-    // request when the question is answered.
-    return Promise.resolve();
-  }
+      // go to:
+      if (label.hasOwnProperty('go to')) {
+        context.navigator.goTo(label['go to']);
+      }
 
-  // go to:
-  if(label.hasOwnProperty('go to')) {
-    context.navigator.goTo(label['go to']);
-  }
+      // swallow pill:
+      if (label.hasOwnProperty('swallow pill')) {
+        context.navigator.swallowPill(label['swallow pill']);
+      }
 
-  // swallow pill:
-  if(label.hasOwnProperty('swallow pill')){
-    context.navigator.swallowPill(label['swallow pill']);
-  }
+      // events:
+      _events(label.events, context);
 
-  // events:
-  _events(label.events, context);
+      // utterances:
+      intents(label.intents, context);
 
-  // utterances:
-  intents(label.intents, context);
+      // condition:
+      condition(label.condition, context);
 
-  // condition:
-  condition(label.condition, context);
-
-  return Promise.resolve();
-
-  } catch (err) {
-    return Promise.reject(err);
-  }
-
+      return Promise.resolve();
+    } catch (err) {
+      return Promise.reject(err);
+    }
   });
-
-}
+};
 

--- a/lib/navigator.js
+++ b/lib/navigator.js
@@ -1,4 +1,4 @@
-'use strict';
+/* eslint no-prototype-builtins:0 */
 
 // Provides a consistent internal API for navigating between
 // states, as well as for determining if the current state
@@ -9,68 +9,68 @@
 // prior to the current evaluation.
 
 module.exports = class Navigator {
-  constructor(pills, context){
-    this.pills   = pills;
+  constructor(pills, context) {
+    this.pills = pills;
     this.context = context;
-    this.dirty   = {};
+    this.dirty = {};
   }
-  get currentPill(){
+  get currentPill() {
     return this.pills[this.currentPillName] || {};
   }
-  get currentLabel(){
+  get currentLabel() {
     return this.currentPill[this.context.navigator.currentLabelName] || {};
   }
-  get hasNavigated(){
+  get hasNavigated() {
     return this.hasChanged('LABEL') || this.hasChanged('PILL');
   }
-  get isWaiting(){
-    return this.get('WAITING') ? true : false;
+  get isWaiting() {
+    return !!this.get('WAITING');
   }
-  get hasFinishedWaiting(){
+  get hasFinishedWaiting() {
     return this.isWaiting && !this.hasNavigated;
   }
-  get currentLabelName(){
+  get currentLabelName() {
     return this.context.sessionAttributes.LABEL;
   }
-  get currentPillName(){
+  get currentPillName() {
     return this.context.sessionAttributes.PILL;
   }
-  get willNavigate(){
+  get willNavigate() {
     // aka "will definitely navigate"
-    let label = this.currentLabel;
-    return label.hasOwnProperty("go to") || label.hasOwnProperty("swallow pill");
+    const label = this.currentLabel;
+    return label.hasOwnProperty('go to') || label.hasOwnProperty('swallow pill');
   }
-  hasChanged(k){
+  hasChanged(k) {
     return this.dirty.hasOwnProperty(k);
   }
-  goTo(labelName){
+  goTo(labelName) {
     this.set('LABEL', labelName);
   }
-  swallowPill(pillName){
+  swallowPill(pillName) {
     this.set('PILL', pillName);
     this.set('LABEL', null);
   }
-  navigate(obj){
+  navigate(obj) {
     // takes any object that has navigable properties
-    if(obj.hasOwnProperty('swallow pill')){
+    if (obj.hasOwnProperty('swallow pill')) {
       this.swallowPill(obj['swallow pill']);
     }
-    if(obj.hasOwnProperty('go to')){
+    if (obj.hasOwnProperty('go to')) {
       this.goTo(obj['go to']);
     }
   }
-  get(k){
+  get(k) {
     return this.context.sessionAttributes[k];
   }
-  set(k,v){
+  set(k, v) {
     this.context.sessionAttributes[k] = v;
-    this.dirty[k]                     = v;
+    this.dirty[k] = v;
   }
-  initialize(k,v) {
+  initialize(k, v) {
     // used to set a navigation value without actually navigating
     this.context.sessionAttributes[k] = v;
   }
-  wait(){
+  wait() {
     // There's a reason we're not just depending on 'shouldEndSession'.
     // First of all, someone *may* want to override shouldEndSession
     // manually.  I know know why they would do that, but it's possible.
@@ -80,13 +80,12 @@ module.exports = class Navigator {
     this.set('WAITING', true);
     this.context.responseBody.shouldEndSession = false;
   }
-  stopWaiting(){
-    return this.set('WAITING', false);
+  stopWaiting() {
     this.context.responseBody.shouldEndSession = true;
+    return this.set('WAITING', false);
   }
-  reload(){
+  reload() {
     this.dirty = {};
     this.set('WAITING', false);
   }
-}
-
+};

--- a/lib/persist.js
+++ b/lib/persist.js
@@ -1,20 +1,18 @@
-'use strict';
+
 
 let adapter;
 
-if(process.env.DYNAMODB_TABLE_NAME){
+if (process.env.DYNAMODB_TABLE_NAME) {
   adapter = require('./adapters/dynamodb');
-} else if(process.env.COUCHDB_DATABASE_NAME){
+} else if (process.env.COUCHDB_DATABASE_NAME) {
   adapter = require('./adapters/couchdb');
 } else {
   adapter = require('./adapters/null');
 }
 
-module.exports = (context) => {
-  return adapter.put(context.session.user.userId, {
-    PILL: context.sessionAttributes.PILL,
-    LABEL: context.sessionAttributes.LABEL,
-    ATTRIBUTES: context.sessionAttributes.ATTRIBUTES
-  });
-}
+module.exports = context => adapter.put(context.session.user.userId, {
+  PILL: context.sessionAttributes.PILL,
+  LABEL: context.sessionAttributes.LABEL,
+  ATTRIBUTES: context.sessionAttributes.ATTRIBUTES,
+});
 

--- a/lib/pill-box.js
+++ b/lib/pill-box.js
@@ -1,52 +1,50 @@
-'use strict';
+/* eslint prefer-destructuring:0 */
 
-const fs                = require('fs');
-const YAML              = require('js-yaml');
-const glob              = require('glob-fs')({ gitignore: true });
-const cutPill           = require('./pill-cutter');
+const fs = require('fs');
+const YAML = require('js-yaml');
+const glob = require('glob-fs')({ gitignore: true });
+const cutPill = require('./pill-cutter');
 
-function loadPillYaml(pillsDirectory, pillName){
-  let yaml     = fs.readFileSync(`${pillsDirectory}/${pillName}.yml`, 'utf8');
-  let segments = yaml.split(/[\-]{3,}/); // a set of 3 or more dashes denotes a section
-  let metadata, imports;
-  let pill     = [];
-  if(segments.length > 1){
-    metadata   = YAML.safeLoad(segments[0]) || {}; // parse metadata section
-    yaml       = segments[1];
-    if(typeof metadata.import === 'string'){
+function loadPillYaml(pillsDirectory, pillName) {
+  let yaml = fs.readFileSync(`${pillsDirectory}/${pillName}.yml`, 'utf8');
+  const segments = yaml.split(/[-]{3,}/); // a set of 3 or more dashes denotes a section
+  let metadata;
+  let imports;
+  const pill = [];
+  if (segments.length > 1) {
+    metadata = YAML.safeLoad(segments[0]) || {}; // parse metadata section
+    yaml = segments[1];
+    if (typeof metadata.import === 'string') {
       imports = [metadata.import];
     } else {
       imports = metadata.import || [];
     }
     // If other pills are listed under import: in the metadata section,
     // load them and prepend to the current pill YAML text in order.
-    imports.forEach(pillName => pill.push(loadPillYaml(pillsDirectory, pillName)));
+    imports.forEach(pillName1 => pill.push(loadPillYaml(pillsDirectory, pillName1)));
   }
   pill.push(yaml);
   return pill.join('\r\n');
 }
 
 module.exports = (pillsDirectory) => {
-
-  let pills = {};
+  const pills = {};
 
   glob.readdirSync(`${pillsDirectory}/**/*.yml`).forEach((f) => {
     // match the name of the pill from the file name
-    let pillKey = f.replace(pillsDirectory, "").match(/\/([\w|\-|\/]+)\.yml/)[1];
-    if(pillKey){
+    const pillKey = f.replace(pillsDirectory, '').match(/\/([\w|\-|/]+)\.yml/)[1];
+    if (pillKey) {
       let pill;
       try {
         pill = YAML.safeLoad(loadPillYaml(pillsDirectory, pillKey));
       } catch (err) {
         return;
       }
-      if(!pill){ return; }
+      if (!pill) { return; }
       cutPill(pill);
       pills[pillKey] = pill;
     }
   });
 
   return pills;
-
-}
-
+};

--- a/lib/pill-cutter.js
+++ b/lib/pill-cutter.js
@@ -1,7 +1,7 @@
-'use strict';
+/* eslint no-param-reassign:0 */
 
-const pascal            = require('pascal-case');
-const expandUtterance   = require('./expand-utterance');
+const pascal = require('pascal-case');
+const expandUtterance = require('./expand-utterance');
 
 // We make an assumption that when you use one of these intent names
 // that you want to use an Amazon built-in intent, so we automagically
@@ -32,11 +32,11 @@ const AMAZON_ALIASES = [
   'scroll up',
   'scroll left',
   'scroll right',
-  'scroll down'
+  'scroll down',
 ];
 
 
-function formatIntentName(utterance){
+function formatIntentName(utterance) {
 // This allows us to write intent names in our pills
 // w/o having to use PascalCase.  Because intent names
 // can't share names with slots, the suffix "Intent" is
@@ -47,9 +47,9 @@ function formatIntentName(utterance){
 // names with their slots inside pills.  I don't know why
 // you would want to do that, however.
 
-  let pascalName = pascal(utterance).replace(/Intent$/) +  'Intent';
-  
-  if(AMAZON_ALIASES.indexOf(utterance.trim()) > -1){
+  let pascalName = `${pascal(utterance).replace(/Intent$/)}Intent`;
+
+  if (AMAZON_ALIASES.indexOf(utterance.trim()) > -1) {
     pascalName = `AMAZON.${pascalName}`;
   }
 
@@ -58,23 +58,23 @@ function formatIntentName(utterance){
 
 
 function processLabel(label) {
-  if(!label.utterances){ return;}
+  if (!label.utterances) { return; }
 
   label.intents = {};
 
   Object.keys(label.utterances).forEach((utterance) => {
-    if(!utterance || utterance.trim() === '?') {
+    if (!utterance || utterance.trim() === '?') {
       // ignore wildcard intent fields
       label.intents[utterance] = label.utterances[utterance];
       return;
     }
-    if (utterance.match(/^AMAZON\./)){ return; }
+    if (utterance.match(/^AMAZON\./)) { return; }
     // ☝ we skip amazon's built-in intents if they are
     // already formatted properly
-    
-    let utteranceConfig = label.utterances[utterance];
 
-    let intent          = Object.assign({}, utteranceConfig);
+    const utteranceConfig = label.utterances[utterance];
+
+    const intent = Object.assign({}, utteranceConfig);
 
     expandUtterance(utterance, intent);
 
@@ -88,11 +88,11 @@ function processLabel(label) {
   delete label.utterances;
 }
 
-function cutPill(pill){
+function cutPill(pill) {
   Object.keys(pill).forEach((labelName) => {
-    if(!labelName.match(/^\./)){
+    if (!labelName.match(/^\./)) {
       // ignore template labels
-      let label = pill[labelName];
+      const label = pill[labelName];
       processLabel(label);
     } else {
       delete pill[labelName];
@@ -101,4 +101,3 @@ function cutPill(pill){
 }
 
 module.exports = cutPill;
-

--- a/lib/pill-swallower.js
+++ b/lib/pill-swallower.js
@@ -1,9 +1,9 @@
-'use strict';
+
 
 const peelLabel = require('./label-peeler');
-const speak     = require('./builders/speak');
+const speak = require('./builders/speak');
 
-function pillSwallower(pill, context){
+function pillSwallower(pill, context) {
   context.sessionAttributes.LABEL = context.sessionAttributes.LABEL || Object.keys(pill)[0];
   // Assume we are not going to navigate to another pill.
   // The only way this gets overridden is if a label in
@@ -13,7 +13,6 @@ function pillSwallower(pill, context){
   // skill can exit state by default when the session is
   // over.
   return peelLabel(pill[context.sessionAttributes.LABEL], context);
-
 }
 
 module.exports = pillSwallower;

--- a/lib/remember.js
+++ b/lib/remember.js
@@ -1,21 +1,21 @@
-'use strict';
+
 
 let adapter;
 
-if(process.env.DYNAMODB_TABLE_NAME){
+if (process.env.DYNAMODB_TABLE_NAME) {
   adapter = require('./adapters/dynamodb');
-} else if(process.env.COUCHDB_DATABASE_NAME){
+} else if (process.env.COUCHDB_DATABASE_NAME) {
   adapter = require('./adapters/couchdb');
 } else {
   adapter = require('./adapters/null');
 }
 
 module.exports = (request) => {
-  if(Object.keys(request.session.attributes || {}).length){
+  if (Object.keys(request.session.attributes || {}).length) {
     // If we already have session attributes,
     // we don't want to spend time making an http
     // request for data we won't use, so do nothing.
-    return Promise.resolve(); 
+    return Promise.resolve();
   }
   return adapter.get(request.session.user.userId)
     .then((doc) => {
@@ -24,5 +24,5 @@ module.exports = (request) => {
       request.SAVED_SESSION = doc;
       return Promise.resolve();
     });
-}
+};
 

--- a/lib/respond.js
+++ b/lib/respond.js
@@ -1,20 +1,19 @@
-'use strict';
+
 
 const coffeeEval = require('./coffee-eval');
 const evalString = require('./eval-string');
-const speak      = require('./builders/speak');
-const assign     = require('./builders/assign');
-const condition  = require('./builders/condition');
-const restore    = require('./builders/restore');
+const speak = require('./builders/speak');
+const assign = require('./builders/assign');
+const condition = require('./builders/condition');
+const restore = require('./builders/restore');
 
 // Used by anything that's a reaction to user interaction
 // such as utterances/intents and events(i.e. request types).
-// Is purposedly more limited than labels in order to 
+// Is purposedly more limited than labels in order to
 // prevent unnecessary complexity.
 
 module.exports = (action, context) => {
-
-  if(!action) { return; }
+  if (!action) { return; }
 
   // restore:
   restore(action.restore, context);
@@ -32,20 +31,19 @@ module.exports = (action, context) => {
   speak(action.speak, context);
 
   // swallow pill:
-  if(action.hasOwnProperty('swallow pill')){
+  if (action.hasOwnProperty('swallow pill')) {
     context.navigator.swallowPill(action['swallow pill']);
     return;
   }
 
   // go to:
-  if(action.hasOwnProperty('go to')) {
+  if (action.hasOwnProperty('go to')) {
     context.navigator.goTo(action['go to']);
   }
 
   // condition:
-  if(action.condition){
+  if (action.condition) {
     condition(action.condition, context);
   }
-
-}
+};
 

--- a/lib/slot-value.js
+++ b/lib/slot-value.js
@@ -1,5 +1,3 @@
-'use strict';
-
 // Makes slot values a little easier to deal with.
 // By default, it assumes that you'll want the most
 // specific value possible, which is whatever is
@@ -7,32 +5,31 @@
 // is resolved, it defaults to the 'literal' value.
 
 module.exports = class {
-  constructor(slot){
+  constructor(slot) {
     this.slot = slot;
     this.slot.resolutions = this.slot.resolutions || {};
-    this.slot.resolutions.resolutionsPerAuthority = this.slot.resolutions.resolutionsPerAuthority || [];
+    this.slot.resolutions.resolutionsPerAuthority =
+      this.slot.resolutions.resolutionsPerAuthority || [];
   }
-  toString(){
+  toString() {
     // Default to the strictest possible value.
     // So first, we pick off the top of what was
     // resolved.  Failing that, we fall back on
     // the spoken value that was returned to us.
     return this.strict || this.literal;
   }
-  isEqualTo(b){
+  isEqualTo(b) {
     return this.toString() === b;
   }
-  get strict(){
+  get strict() {
     return this.slot.resolutions.resolutionsPerAuthority.map((r) => {
-      if(r.status.code === 'ER_SUCCESS_MATCH'){
+      if (r.status.code === 'ER_SUCCESS_MATCH') {
         return r.values[0].value.name;
-      } else {
-        return '';
       }
+      return '';
     })[0];
   }
-  get literal(){
+  get literal() {
     return this.slot.value || '';
   }
-}
-
+};

--- a/lib/xml-parser.js
+++ b/lib/xml-parser.js
@@ -1,15 +1,15 @@
-'use strict';
 
-const xml2js      = require('xml2js').parseString;
+
+const xml2js = require('xml2js').parseString;
 
 module.exports = (xml) => {
   let output;
-  xml2js(xml, function (err, result) {
-    if(err){
+  xml2js(xml, (err, result) => {
+    if (err) {
       throw new Error(err);
     }
     output = result;
   });
   return output;
-}
+};
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3942 @@
+{
+  "name": "skills-in-pills",
+  "version": "0.0.5",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "acorn": {
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
+      "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
+    },
+    "acorn-jsx": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+      "dev": true,
+      "requires": {
+        "acorn": "3.3.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+          "dev": true
+        }
+      }
+    },
+    "ajv": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.3.tgz",
+      "integrity": "sha1-wG9Zh3jETGsWGrr+NGa4GtGBTtI=",
+      "dev": true,
+      "requires": {
+        "co": "4.6.0",
+        "fast-deep-equal": "1.0.0",
+        "json-schema-traverse": "0.3.1",
+        "json-stable-stringify": "1.0.1"
+      },
+      "dependencies": {
+        "json-stable-stringify": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+          "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+          "dev": true,
+          "requires": {
+            "jsonify": "0.0.0"
+          }
+        }
+      }
+    },
+    "ajv-keywords": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.0.tgz",
+      "integrity": "sha1-opbhf3v658HOT34N5T0pyzIWLfA=",
+      "dev": true
+    },
+    "anchor-markdown-header": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/anchor-markdown-header/-/anchor-markdown-header-0.5.7.tgz",
+      "integrity": "sha1-BFBj125qH5zTJ6V6ASaqD97Dcac=",
+      "dev": true,
+      "requires": {
+        "emoji-regex": "6.1.3"
+      }
+    },
+    "ansi-escapes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
+      "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true
+    },
+    "ansi-wrap": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+      "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768="
+    },
+    "ansi-yellow": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-yellow/-/ansi-yellow-0.1.1.tgz",
+      "integrity": "sha1-y5NW8vRscy8OMZnmEClVp32oPB0=",
+      "requires": {
+        "ansi-wrap": "0.1.0"
+      }
+    },
+    "argparse": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+      "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+      "requires": {
+        "sprintf-js": "1.0.3"
+      }
+    },
+    "arr-diff": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+      "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+      "requires": {
+        "arr-flatten": "1.1.0"
+      }
+    },
+    "arr-flatten": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+    },
+    "array-filter": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
+      "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw="
+    },
+    "array-map": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
+      "integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI="
+    },
+    "array-reduce": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
+      "integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys="
+    },
+    "array-slice": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
+      "integrity": "sha1-3Tz7gO15c6dRF82sabC5nshhhvU="
+    },
+    "array-union": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+      "dev": true,
+      "requires": {
+        "array-uniq": "1.0.3"
+      }
+    },
+    "array-uniq": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+      "dev": true
+    },
+    "array-unique": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+      "dev": true
+    },
+    "asn1.js": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
+      "integrity": "sha1-SLokC0WpKA6UdImQull9IWYX/UA=",
+      "requires": {
+        "bn.js": "4.11.8",
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.0"
+      }
+    },
+    "assert": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
+      "integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
+      "requires": {
+        "util": "0.10.3"
+      }
+    },
+    "astw": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/astw/-/astw-2.2.0.tgz",
+      "integrity": "sha1-e9QXhNMkk5h66yOba04cV6hzuRc=",
+      "requires": {
+        "acorn": "4.0.13"
+      }
+    },
+    "async": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+    },
+    "aws-sdk": {
+      "version": "2.128.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.128.0.tgz",
+      "integrity": "sha1-ub5WHF43M8AGjGEhtYdnRTRmLUs=",
+      "dev": true,
+      "requires": {
+        "buffer": "4.9.1",
+        "crypto-browserify": "1.0.9",
+        "events": "1.1.1",
+        "jmespath": "0.15.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.1.0",
+        "xml2js": "0.4.17",
+        "xmlbuilder": "4.2.1"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "4.9.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+          "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+          "dev": true,
+          "requires": {
+            "base64-js": "1.2.1",
+            "ieee754": "1.1.8",
+            "isarray": "1.0.0"
+          }
+        },
+        "crypto-browserify": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-1.0.9.tgz",
+          "integrity": "sha1-zFRJaF37hesRyYKKzHy4erW7/MA=",
+          "dev": true
+        },
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+          "dev": true
+        },
+        "sax": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+          "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o=",
+          "dev": true
+        },
+        "url": {
+          "version": "0.10.3",
+          "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+          "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+          "dev": true,
+          "requires": {
+            "punycode": "1.3.2",
+            "querystring": "0.2.0"
+          }
+        },
+        "xml2js": {
+          "version": "0.4.17",
+          "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
+          "integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg=",
+          "dev": true,
+          "requires": {
+            "sax": "1.2.1",
+            "xmlbuilder": "4.2.1"
+          }
+        },
+        "xmlbuilder": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
+          "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=",
+          "dev": true,
+          "requires": {
+            "lodash": "4.17.4"
+          }
+        }
+      }
+    },
+    "babel-code-frame": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        }
+      }
+    },
+    "bail": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.2.tgz",
+      "integrity": "sha1-99bBcxYwqfnw1NNe0fli4gdKF2Q=",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "base64-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz",
+      "integrity": "sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw=="
+    },
+    "bluebird": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+      "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
+    },
+    "bn.js": {
+      "version": "4.11.8",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+    },
+    "boundary": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/boundary/-/boundary-1.0.1.tgz",
+      "integrity": "sha1-TWfcJgLAzBbdm85+v4fpSCkPWBI=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "braces": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+      "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+      "requires": {
+        "expand-range": "1.8.2",
+        "preserve": "0.2.0",
+        "repeat-element": "1.1.2"
+      }
+    },
+    "brorand": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+    },
+    "browser-pack": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-6.0.2.tgz",
+      "integrity": "sha1-+GzWzvT1MAyOY+B6TVEvZfv/RTE=",
+      "requires": {
+        "combine-source-map": "0.7.2",
+        "defined": "1.0.0",
+        "JSONStream": "1.3.1",
+        "through2": "2.0.3",
+        "umd": "3.0.1"
+      }
+    },
+    "browser-resolve": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
+      "integrity": "sha1-j/CbCixCFxihBRwmCzLkj0QpOM4=",
+      "requires": {
+        "resolve": "1.1.7"
+      },
+      "dependencies": {
+        "resolve": {
+          "version": "1.1.7",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
+        }
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+      "dev": true
+    },
+    "browserify": {
+      "version": "14.4.0",
+      "resolved": "https://registry.npmjs.org/browserify/-/browserify-14.4.0.tgz",
+      "integrity": "sha1-CJo0Y69Y0OSNjNQHCz90ZU1avKk=",
+      "requires": {
+        "assert": "1.4.1",
+        "browser-pack": "6.0.2",
+        "browser-resolve": "1.11.2",
+        "browserify-zlib": "0.1.4",
+        "buffer": "5.0.8",
+        "cached-path-relative": "1.0.1",
+        "concat-stream": "1.5.2",
+        "console-browserify": "1.1.0",
+        "constants-browserify": "1.0.0",
+        "crypto-browserify": "3.11.1",
+        "defined": "1.0.0",
+        "deps-sort": "2.0.0",
+        "domain-browser": "1.1.7",
+        "duplexer2": "0.1.4",
+        "events": "1.1.1",
+        "glob": "7.1.2",
+        "has": "1.0.1",
+        "htmlescape": "1.1.1",
+        "https-browserify": "1.0.0",
+        "inherits": "2.0.3",
+        "insert-module-globals": "7.0.1",
+        "JSONStream": "1.3.1",
+        "labeled-stream-splicer": "2.0.0",
+        "module-deps": "4.1.1",
+        "os-browserify": "0.1.2",
+        "parents": "1.0.1",
+        "path-browserify": "0.0.0",
+        "process": "0.11.10",
+        "punycode": "1.4.1",
+        "querystring-es3": "0.2.1",
+        "read-only-stream": "2.0.0",
+        "readable-stream": "2.3.3",
+        "resolve": "1.4.0",
+        "shasum": "1.0.2",
+        "shell-quote": "1.6.1",
+        "stream-browserify": "2.0.1",
+        "stream-http": "2.7.2",
+        "string_decoder": "1.0.3",
+        "subarg": "1.0.0",
+        "syntax-error": "1.3.0",
+        "through2": "2.0.3",
+        "timers-browserify": "1.4.2",
+        "tty-browserify": "0.0.0",
+        "url": "0.11.0",
+        "util": "0.10.3",
+        "vm-browserify": "0.0.4",
+        "xtend": "4.0.1"
+      }
+    },
+    "browserify-aes": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.8.tgz",
+      "integrity": "sha512-WYCMOT/PtGTlpOKFht0YJFYcPy6pLCR98CtWfzK13zoynLlBMvAdEMSRGmgnJCw2M2j/5qxBkinZQFobieM8dQ==",
+      "requires": {
+        "buffer-xor": "1.0.3",
+        "cipher-base": "1.0.4",
+        "create-hash": "1.1.3",
+        "evp_bytestokey": "1.0.3",
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "browserify-cipher": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
+      "integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
+      "requires": {
+        "browserify-aes": "1.0.8",
+        "browserify-des": "1.0.0",
+        "evp_bytestokey": "1.0.3"
+      }
+    },
+    "browserify-des": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
+      "integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=",
+      "requires": {
+        "cipher-base": "1.0.4",
+        "des.js": "1.0.0",
+        "inherits": "2.0.3"
+      }
+    },
+    "browserify-rsa": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
+      "requires": {
+        "bn.js": "4.11.8",
+        "randombytes": "2.0.5"
+      }
+    },
+    "browserify-sign": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
+      "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
+      "requires": {
+        "bn.js": "4.11.8",
+        "browserify-rsa": "4.0.1",
+        "create-hash": "1.1.3",
+        "create-hmac": "1.1.6",
+        "elliptic": "6.4.0",
+        "inherits": "2.0.3",
+        "parse-asn1": "5.1.0"
+      }
+    },
+    "browserify-zlib": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+      "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
+      "requires": {
+        "pako": "0.2.9"
+      }
+    },
+    "buffer": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.0.8.tgz",
+      "integrity": "sha512-xXvjQhVNz50v2nPeoOsNqWCLGfiv4ji/gXZM28jnVwdLJxH4mFyqgqCKfaK9zf1KUbG6zTkjLOy7ou+jSMarGA==",
+      "requires": {
+        "base64-js": "1.2.1",
+        "ieee754": "1.1.8"
+      }
+    },
+    "buffer-xor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
+    },
+    "builtin-modules": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+      "dev": true
+    },
+    "builtin-status-codes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+      "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug="
+    },
+    "cached-path-relative": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cached-path-relative/-/cached-path-relative-1.0.1.tgz",
+      "integrity": "sha1-0JxLUoAKpMB44t2BqGmqyQ0uVOc="
+    },
+    "caller-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+      "dev": true,
+      "requires": {
+        "callsites": "0.2.0"
+      }
+    },
+    "callsites": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+      "dev": true
+    },
+    "camel-case": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
+      "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
+      "requires": {
+        "no-case": "2.3.2",
+        "upper-case": "1.1.3"
+      }
+    },
+    "camelize": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz",
+      "integrity": "sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs="
+    },
+    "ccount": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.2.tgz",
+      "integrity": "sha1-U7ai+BW7d7nChx97mnLDol8djok=",
+      "dev": true
+    },
+    "chalk": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
+      "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "3.2.0",
+        "escape-string-regexp": "1.0.5",
+        "supports-color": "4.4.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "supports-color": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
+    "character-entities": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.1.tgz",
+      "integrity": "sha1-92hxvl72bdt/j440eOzDdMJ9bco=",
+      "dev": true
+    },
+    "character-entities-html4": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-1.1.1.tgz",
+      "integrity": "sha1-NZoqSg9+KdPcKsmb2+Ie45Q46lA=",
+      "dev": true
+    },
+    "character-entities-legacy": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.1.tgz",
+      "integrity": "sha1-9Ad53xoQGHK7UQo9KV4fzPFHIC8=",
+      "dev": true
+    },
+    "character-reference-invalid": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.1.tgz",
+      "integrity": "sha1-lCg191Dk7GGjCOYMLvjMEBEgLvw=",
+      "dev": true
+    },
+    "charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
+    },
+    "chrono-node": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/chrono-node/-/chrono-node-1.3.5.tgz",
+      "integrity": "sha1-oklSmKMtqCvMAa2b59d++l4kQSI=",
+      "requires": {
+        "moment": "2.18.1"
+      }
+    },
+    "cipher-base": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+      "requires": {
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "circular-json": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+      "dev": true
+    },
+    "cli-cursor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "2.0.0"
+      }
+    },
+    "cli-width": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+      "dev": true
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true
+    },
+    "coffeescript": {
+      "version": "1.12.7",
+      "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-1.12.7.tgz",
+      "integrity": "sha512-pLXHFxQMPklVoEekowk8b3erNynC+DVJzChxS/LCBBgR6/8AJkHivkm//zbowcfc7BTCAjryuhx6gPqPRfsFoA=="
+    },
+    "collapse-white-space": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.3.tgz",
+      "integrity": "sha1-S5BvZw5aljqHt2sOFolkM0G2Ajw=",
+      "dev": true
+    },
+    "color-convert": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
+      "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "combine-source-map": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.7.2.tgz",
+      "integrity": "sha1-CHAxKFazB6h8xKxIbzqaYq7MwJ4=",
+      "requires": {
+        "convert-source-map": "1.1.3",
+        "inline-source-map": "0.6.2",
+        "lodash.memoize": "3.0.4",
+        "source-map": "0.5.7"
+      }
+    },
+    "commander": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+      "dev": true,
+      "requires": {
+        "graceful-readlink": "1.0.1"
+      }
+    },
+    "component-emitter": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "concat-stream": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
+      "integrity": "sha1-cIl4Yk2FavQaWnQd790mHadSwmY=",
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.0.6",
+        "typedarray": "0.0.6"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+          "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "0.10.31",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
+      }
+    },
+    "console-browserify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+      "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
+      "requires": {
+        "date-now": "0.1.4"
+      }
+    },
+    "constants-browserify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
+      "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U="
+    },
+    "contains-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
+      "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
+      "dev": true
+    },
+    "convert-source-map": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
+      "integrity": "sha1-SCnId+n+SbMWHzvzZziI4gRpmGA="
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "create-ecdh": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
+      "integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=",
+      "requires": {
+        "bn.js": "4.11.8",
+        "elliptic": "6.4.0"
+      }
+    },
+    "create-hash": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
+      "integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=",
+      "requires": {
+        "cipher-base": "1.0.4",
+        "inherits": "2.0.3",
+        "ripemd160": "2.0.1",
+        "sha.js": "2.4.9"
+      }
+    },
+    "create-hmac": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz",
+      "integrity": "sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=",
+      "requires": {
+        "cipher-base": "1.0.4",
+        "create-hash": "1.1.3",
+        "inherits": "2.0.3",
+        "ripemd160": "2.0.1",
+        "safe-buffer": "5.1.1",
+        "sha.js": "2.4.9"
+      }
+    },
+    "cross-spawn": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "4.1.1",
+        "shebang-command": "1.2.0",
+        "which": "1.3.0"
+      }
+    },
+    "crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
+    },
+    "crypto-browserify": {
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.1.tgz",
+      "integrity": "sha512-Na7ZlwCOqoaW5RwUK1WpXws2kv8mNhWdTlzob0UXulk6G9BDbyiJaGTYBIX61Ozn9l1EPPJpICZb4DaOpT9NlQ==",
+      "requires": {
+        "browserify-cipher": "1.0.0",
+        "browserify-sign": "4.0.4",
+        "create-ecdh": "4.0.0",
+        "create-hash": "1.1.3",
+        "create-hmac": "1.1.6",
+        "diffie-hellman": "5.0.2",
+        "inherits": "2.0.3",
+        "pbkdf2": "3.0.14",
+        "public-encrypt": "4.0.0",
+        "randombytes": "2.0.5"
+      }
+    },
+    "date-now": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+      "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs="
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "defined": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
+    },
+    "del": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+      "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+      "dev": true,
+      "requires": {
+        "globby": "5.0.0",
+        "is-path-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.0",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "rimraf": "2.6.2"
+      }
+    },
+    "deps-sort": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-2.0.0.tgz",
+      "integrity": "sha1-CRckkC6EZYJg65EHSMzNGvbiH7U=",
+      "requires": {
+        "JSONStream": "1.3.1",
+        "shasum": "1.0.2",
+        "subarg": "1.0.0",
+        "through2": "2.0.3"
+      }
+    },
+    "des.js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
+      "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
+      "requires": {
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.0"
+      }
+    },
+    "detect-file": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-0.1.0.tgz",
+      "integrity": "sha1-STXe39lIhkjgBrASlWbpOGcR6mM=",
+      "requires": {
+        "fs-exists-sync": "0.1.0"
+      }
+    },
+    "detective": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/detective/-/detective-4.5.0.tgz",
+      "integrity": "sha1-blqMaybmx6JUsca210kNmOyR7dE=",
+      "requires": {
+        "acorn": "4.0.13",
+        "defined": "1.0.0"
+      }
+    },
+    "diff": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+      "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
+      "dev": true
+    },
+    "diffie-hellman": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
+      "integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
+      "requires": {
+        "bn.js": "4.11.8",
+        "miller-rabin": "4.0.1",
+        "randombytes": "2.0.5"
+      }
+    },
+    "doctoc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/doctoc/-/doctoc-1.3.0.tgz",
+      "integrity": "sha1-fwg5hR3VjICKLK5V2VBOAS0I7jA=",
+      "dev": true,
+      "requires": {
+        "anchor-markdown-header": "0.5.7",
+        "htmlparser2": "3.9.2",
+        "markdown-to-ast": "3.4.0",
+        "minimist": "1.2.0",
+        "underscore": "1.8.3",
+        "update-section": "0.3.3"
+      },
+      "dependencies": {
+        "underscore": {
+          "version": "1.8.3",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+          "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
+          "dev": true
+        }
+      }
+    },
+    "doctrine": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
+      "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
+      "dev": true,
+      "requires": {
+        "esutils": "2.0.2",
+        "isarray": "1.0.0"
+      }
+    },
+    "dom-serializer": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+      "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1.1.3",
+        "entities": "1.1.1"
+      },
+      "dependencies": {
+        "domelementtype": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+          "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
+          "dev": true
+        }
+      }
+    },
+    "domain-browser": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
+      "integrity": "sha1-hnqksJP6oF8d4IwG9NeyH9+GmLw="
+    },
+    "domelementtype": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+      "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
+      "dev": true
+    },
+    "domhandler": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.1.tgz",
+      "integrity": "sha1-iS5HAAqZvlW783dP/qBWHYh5wlk=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1.3.0"
+      }
+    },
+    "domutils": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.6.2.tgz",
+      "integrity": "sha1-GVjMC0yUJuntNn+xyOhUiRsPo/8=",
+      "dev": true,
+      "requires": {
+        "dom-serializer": "0.1.0",
+        "domelementtype": "1.3.0"
+      }
+    },
+    "dotdir-regex": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/dotdir-regex/-/dotdir-regex-0.1.0.tgz",
+      "integrity": "sha1-1F30yIY75vVZPXFpFDgXZ+k4wLY="
+    },
+    "duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+      "requires": {
+        "readable-stream": "2.3.3"
+      }
+    },
+    "elliptic": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
+      "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
+      "requires": {
+        "bn.js": "4.11.8",
+        "brorand": "1.1.0",
+        "hash.js": "1.1.3",
+        "hmac-drbg": "1.0.1",
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.0",
+        "minimalistic-crypto-utils": "1.0.1"
+      }
+    },
+    "emoji-regex": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.1.3.tgz",
+      "integrity": "sha1-7HmjlpsC0uzytyJUJ5v5m8eoOTI=",
+      "dev": true
+    },
+    "ends-with": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/ends-with/-/ends-with-0.2.0.tgz",
+      "integrity": "sha1-L52pjVelDP2kVxzkM5AAUA9Oa4o="
+    },
+    "entities": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+      "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
+      "dev": true
+    },
+    "error-ex": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "0.2.1"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "eslint": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.8.0.tgz",
+      "integrity": "sha1-Ip7w41Tg5h2DfHqA/fuoJeGZgV4=",
+      "dev": true,
+      "requires": {
+        "ajv": "5.2.3",
+        "babel-code-frame": "6.26.0",
+        "chalk": "2.1.0",
+        "concat-stream": "1.6.0",
+        "cross-spawn": "5.1.0",
+        "debug": "3.1.0",
+        "doctrine": "2.0.0",
+        "eslint-scope": "3.7.1",
+        "espree": "3.5.1",
+        "esquery": "1.0.0",
+        "estraverse": "4.2.0",
+        "esutils": "2.0.2",
+        "file-entry-cache": "2.0.0",
+        "functional-red-black-tree": "1.0.1",
+        "glob": "7.1.2",
+        "globals": "9.18.0",
+        "ignore": "3.3.5",
+        "imurmurhash": "0.1.4",
+        "inquirer": "3.3.0",
+        "is-resolvable": "1.0.0",
+        "js-yaml": "3.10.0",
+        "json-stable-stringify": "1.0.1",
+        "levn": "0.3.0",
+        "lodash": "4.17.4",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "natural-compare": "1.4.0",
+        "optionator": "0.8.2",
+        "path-is-inside": "1.0.2",
+        "pluralize": "7.0.0",
+        "progress": "2.0.0",
+        "require-uncached": "1.0.3",
+        "semver": "5.4.1",
+        "strip-ansi": "4.0.0",
+        "strip-json-comments": "2.0.1",
+        "table": "4.0.2",
+        "text-table": "0.2.0"
+      },
+      "dependencies": {
+        "concat-stream": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+          "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+          "dev": true,
+          "requires": {
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.3",
+            "typedarray": "0.0.6"
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "json-stable-stringify": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+          "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+          "dev": true,
+          "requires": {
+            "jsonify": "0.0.0"
+          }
+        }
+      }
+    },
+    "eslint-config-airbnb-base": {
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-12.0.2.tgz",
+      "integrity": "sha512-rQqOvAzrMC3BBCH6Dd/1RenDi+RW4vdgnh8xcPf6sgd324ad6aX7hSZ52L1SfDGe2VsZR2yB5uPvDfXYvxHZmA==",
+      "dev": true,
+      "requires": {
+        "eslint-restricted-globals": "0.1.1"
+      }
+    },
+    "eslint-import-resolver-node": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.1.tgz",
+      "integrity": "sha512-yUtXS15gIcij68NmXmP9Ni77AQuCN0itXbCc/jWd8C6/yKZaSNXicpC8cgvjnxVdmfsosIXrjpzFq7GcDryb6A==",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "resolve": "1.4.0"
+      }
+    },
+    "eslint-module-utils": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.1.1.tgz",
+      "integrity": "sha512-jDI/X5l/6D1rRD/3T43q8Qgbls2nq5km5KSqiwlyUbGo5+04fXhMKdCPhjwbqAa6HXWaMxj8Q4hQDIh7IadJQw==",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "pkg-dir": "1.0.0"
+      }
+    },
+    "eslint-plugin-import": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.7.0.tgz",
+      "integrity": "sha512-HGYmpU9f/zJaQiKNQOVfHUh2oLWW3STBrCgH0sHTX1xtsxYlH1zjLh8FlQGEIdZSdTbUMaV36WaZ6ImXkenGxQ==",
+      "dev": true,
+      "requires": {
+        "builtin-modules": "1.1.1",
+        "contains-path": "0.1.0",
+        "debug": "2.6.9",
+        "doctrine": "1.5.0",
+        "eslint-import-resolver-node": "0.3.1",
+        "eslint-module-utils": "2.1.1",
+        "has": "1.0.1",
+        "lodash.cond": "4.5.2",
+        "minimatch": "3.0.4",
+        "read-pkg-up": "2.0.0"
+      },
+      "dependencies": {
+        "doctrine": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+          "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+          "dev": true,
+          "requires": {
+            "esutils": "2.0.2",
+            "isarray": "1.0.0"
+          }
+        }
+      }
+    },
+    "eslint-restricted-globals": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-restricted-globals/-/eslint-restricted-globals-0.1.1.tgz",
+      "integrity": "sha1-NfDVy8ZMLj7WLpO0saevBbp+1Nc=",
+      "dev": true
+    },
+    "eslint-scope": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
+      "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
+      "dev": true,
+      "requires": {
+        "esrecurse": "4.2.0",
+        "estraverse": "4.2.0"
+      }
+    },
+    "espree": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.1.tgz",
+      "integrity": "sha1-DJiLirRttTEAoZVK5LqZXd0n2H4=",
+      "dev": true,
+      "requires": {
+        "acorn": "5.1.2",
+        "acorn-jsx": "3.0.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.2.tgz",
+          "integrity": "sha512-o96FZLJBPY1lvTuJylGA9Bk3t/GKPPJG8H0ydQQl01crzwJgspa4AEIq/pVTXigmK0PHVQhiAtn8WMBLL9D2WA==",
+          "dev": true
+        }
+      }
+    },
+    "esprima": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+    },
+    "esquery": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
+      "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
+      "dev": true,
+      "requires": {
+        "estraverse": "4.2.0"
+      }
+    },
+    "esrecurse": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
+      "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
+      "dev": true,
+      "requires": {
+        "estraverse": "4.2.0",
+        "object-assign": "4.1.1"
+      }
+    },
+    "estraverse": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
+    },
+    "events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+    },
+    "evp_bytestokey": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+      "requires": {
+        "md5.js": "1.3.4",
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "expand-brackets": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+      "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+      "requires": {
+        "is-posix-bracket": "0.1.1"
+      }
+    },
+    "expand-range": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+      "requires": {
+        "fill-range": "2.2.3"
+      }
+    },
+    "expand-tilde": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
+      "integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
+      "requires": {
+        "os-homedir": "1.0.2"
+      }
+    },
+    "export-files": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/export-files/-/export-files-2.1.1.tgz",
+      "integrity": "sha1-u/ZFdAU6CeTrmOX0NQHVcrLDzn8=",
+      "requires": {
+        "lazy-cache": "1.0.4"
+      },
+      "dependencies": {
+        "lazy-cache": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+          "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
+        }
+      }
+    },
+    "extend": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+      "dev": true
+    },
+    "extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "requires": {
+        "is-extendable": "0.1.1"
+      }
+    },
+    "external-editor": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.0.5.tgz",
+      "integrity": "sha512-Msjo64WT5W+NhOpQXh0nOHm+n0RfU1QUwDnKYvJ8dEJ8zlwLrqXNTv5mSUTJpepf41PDJGyhueTw2vNZW+Fr/w==",
+      "dev": true,
+      "requires": {
+        "iconv-lite": "0.4.19",
+        "jschardet": "1.5.1",
+        "tmp": "0.0.33"
+      }
+    },
+    "extglob": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+      "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+      "requires": {
+        "is-extglob": "1.0.0"
+      }
+    },
+    "fast-deep-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
+      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
+      "dev": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "figures": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "1.0.5"
+      }
+    },
+    "file-entry-cache": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+      "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+      "dev": true,
+      "requires": {
+        "flat-cache": "1.3.0",
+        "object-assign": "4.1.1"
+      }
+    },
+    "filename-regex": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
+    },
+    "fill-range": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+      "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+      "requires": {
+        "is-number": "2.1.0",
+        "isobject": "2.1.0",
+        "randomatic": "1.1.7",
+        "repeat-element": "1.1.2",
+        "repeat-string": "1.6.1"
+      }
+    },
+    "find-up": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+      "dev": true,
+      "requires": {
+        "path-exists": "2.1.0",
+        "pinkie-promise": "2.0.1"
+      }
+    },
+    "findup-sync": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-1.0.0.tgz",
+      "integrity": "sha1-b35LV7buOkA3tEFOrt6j9Y9x4Ow=",
+      "requires": {
+        "detect-file": "0.1.0",
+        "is-glob": "2.0.1",
+        "micromatch": "2.3.11",
+        "resolve-dir": "0.1.1"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "1.1.5"
+          }
+        },
+        "micromatch": {
+          "version": "2.3.11",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+          "requires": {
+            "arr-diff": "2.0.0",
+            "array-unique": "0.2.1",
+            "braces": "1.8.5",
+            "expand-brackets": "0.1.5",
+            "extglob": "0.3.2",
+            "filename-regex": "2.0.1",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1",
+            "kind-of": "3.2.2",
+            "normalize-path": "2.1.1",
+            "object.omit": "2.0.1",
+            "parse-glob": "3.0.4",
+            "regex-cache": "0.4.4"
+          }
+        },
+        "object.omit": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+          "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+          "requires": {
+            "for-own": "0.1.5",
+            "is-extendable": "0.1.1"
+          }
+        }
+      }
+    },
+    "flat-cache": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
+      "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+      "dev": true,
+      "requires": {
+        "circular-json": "0.3.3",
+        "del": "2.2.2",
+        "graceful-fs": "4.1.11",
+        "write": "0.2.1"
+      }
+    },
+    "follow-redirects": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.2.5.tgz",
+      "integrity": "sha512-lMhwQTryFbG+wYsAIEKC1Kf5IGDlVNnONRogIBllh7LLoV7pNIxW0z9fhjRar9NBql+hd2Y49KboVVNxf6GEfg==",
+      "requires": {
+        "debug": "2.6.9"
+      }
+    },
+    "for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+    },
+    "for-own": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+      "requires": {
+        "for-in": "1.0.2"
+      }
+    },
+    "fs-exists-sync": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
+      "integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0="
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
+    "get-value": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-1.3.1.tgz",
+      "integrity": "sha1-isfvTyA4I5KyZGVI+bmtLcbIlkI=",
+      "requires": {
+        "arr-flatten": "1.1.0",
+        "is-extendable": "0.1.1",
+        "lazy-cache": "0.2.7",
+        "noncharacters": "1.1.0"
+      },
+      "dependencies": {
+        "lazy-cache": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+          "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U="
+        }
+      }
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
+    },
+    "glob-base": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+      "requires": {
+        "glob-parent": "2.0.0",
+        "is-glob": "2.0.1"
+      },
+      "dependencies": {
+        "glob-parent": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+          "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+          "requires": {
+            "is-glob": "2.0.1"
+          }
+        }
+      }
+    },
+    "glob-fs": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/glob-fs/-/glob-fs-0.1.7.tgz",
+      "integrity": "sha512-f0U3u9xK8MEYtKDCnZXvZrZAy4uNp+KSA4xfaKI/NxbE6HXhqUBQ485Uwd6jQa/Q6z1yKi804WT9y53RrwuMxQ==",
+      "requires": {
+        "async": "1.5.2",
+        "bluebird": "2.11.0",
+        "component-emitter": "1.2.1",
+        "ends-with": "0.2.0",
+        "export-files": "2.1.1",
+        "extend-shallow": "2.0.1",
+        "get-value": "1.3.1",
+        "glob-fs-dotfiles": "0.1.6",
+        "glob-fs-gitignore": "0.1.6",
+        "glob-parent": "1.3.0",
+        "graceful-fs": "4.1.11",
+        "is-dotdir": "0.1.0",
+        "is-dotfile": "1.0.3",
+        "is-glob": "2.0.1",
+        "is-windows": "0.1.1",
+        "kind-of": "2.0.1",
+        "lazy-cache": "0.1.0",
+        "micromatch": "github:jonschlinkert/micromatch#b0ac0b7cea8d90f97630c027d0116a8aef06bfdc",
+        "mixin-object": "2.0.1",
+        "object-visit": "0.1.0",
+        "object.omit": "1.1.0",
+        "parse-filepath": "0.6.3",
+        "relative": "3.0.2",
+        "set-value": "0.2.0",
+        "starts-with": "1.0.2",
+        "through2": "2.0.3"
+      }
+    },
+    "glob-fs-dotfiles": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/glob-fs-dotfiles/-/glob-fs-dotfiles-0.1.6.tgz",
+      "integrity": "sha1-tPF7c8GIQYq6R80gbPWnImtKiUk="
+    },
+    "glob-fs-gitignore": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/glob-fs-gitignore/-/glob-fs-gitignore-0.1.6.tgz",
+      "integrity": "sha1-iF5vQS+FnMWXVhVIKdvVVybN6ZI=",
+      "requires": {
+        "findup-sync": "1.0.0",
+        "micromatch": "2.3.11",
+        "parse-gitignore": "0.2.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "1.1.5"
+          }
+        },
+        "micromatch": {
+          "version": "2.3.11",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+          "requires": {
+            "arr-diff": "2.0.0",
+            "array-unique": "0.2.1",
+            "braces": "1.8.5",
+            "expand-brackets": "0.1.5",
+            "extglob": "0.3.2",
+            "filename-regex": "2.0.1",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1",
+            "kind-of": "3.2.2",
+            "normalize-path": "2.1.1",
+            "object.omit": "2.0.1",
+            "parse-glob": "3.0.4",
+            "regex-cache": "0.4.4"
+          }
+        },
+        "object.omit": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+          "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+          "requires": {
+            "for-own": "0.1.5",
+            "is-extendable": "0.1.1"
+          }
+        }
+      }
+    },
+    "glob-parent": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-1.3.0.tgz",
+      "integrity": "sha1-lx7dgW7V21hwW1gHlkemTQrveWg=",
+      "requires": {
+        "is-glob": "2.0.1"
+      }
+    },
+    "global-modules": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
+      "integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
+      "requires": {
+        "global-prefix": "0.1.5",
+        "is-windows": "0.2.0"
+      },
+      "dependencies": {
+        "is-windows": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
+          "integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw="
+        }
+      }
+    },
+    "global-prefix": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
+      "integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
+      "requires": {
+        "homedir-polyfill": "1.0.1",
+        "ini": "1.3.4",
+        "is-windows": "0.2.0",
+        "which": "1.3.0"
+      },
+      "dependencies": {
+        "is-windows": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
+          "integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw="
+        }
+      }
+    },
+    "globals": {
+      "version": "9.18.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+      "dev": true
+    },
+    "globby": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+      "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+      "dev": true,
+      "requires": {
+        "array-union": "1.0.2",
+        "arrify": "1.0.1",
+        "glob": "7.1.2",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+    },
+    "graceful-readlink": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+      "dev": true
+    },
+    "growl": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+      "dev": true
+    },
+    "has": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+      "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+      "requires": {
+        "function-bind": "1.1.1"
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "has-flag": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+      "dev": true
+    },
+    "hash-base": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
+      "integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
+      "requires": {
+        "inherits": "2.0.3"
+      }
+    },
+    "hash.js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+      "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+      "requires": {
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.0"
+      }
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
+    },
+    "hmac-drbg": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+      "requires": {
+        "hash.js": "1.1.3",
+        "minimalistic-assert": "1.0.0",
+        "minimalistic-crypto-utils": "1.0.1"
+      }
+    },
+    "homedir-polyfill": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
+      "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
+      "requires": {
+        "parse-passwd": "1.0.0"
+      }
+    },
+    "hosted-git-info": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
+      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
+      "dev": true
+    },
+    "html-entities": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
+      "integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8="
+    },
+    "htmlescape": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz",
+      "integrity": "sha1-OgPtwiFLyjtmQko+eVk0lQnLA1E="
+    },
+    "htmlparser2": {
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
+      "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1.3.0",
+        "domhandler": "2.4.1",
+        "domutils": "1.6.2",
+        "entities": "1.1.1",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3"
+      }
+    },
+    "https-browserify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
+      "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
+    },
+    "iconv-lite": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+      "dev": true
+    },
+    "ieee754": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
+      "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
+    },
+    "ignore": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.5.tgz",
+      "integrity": "sha512-JLH93mL8amZQhh/p6mfQgVBH3M6epNq3DfsXsTSuSrInVjwyYlFE1nv2AgfRCC8PoOhM0jwQ5v8s9LgbK7yGDw==",
+      "dev": true
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
+    "indexof": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "ini": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+      "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4="
+    },
+    "inline-source-map": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.6.2.tgz",
+      "integrity": "sha1-+Tk0ccGKedFyT4Y/o4tYY3Ct4qU=",
+      "requires": {
+        "source-map": "0.5.7"
+      }
+    },
+    "inquirer": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "3.0.0",
+        "chalk": "2.1.0",
+        "cli-cursor": "2.1.0",
+        "cli-width": "2.2.0",
+        "external-editor": "2.0.5",
+        "figures": "2.0.0",
+        "lodash": "4.17.4",
+        "mute-stream": "0.0.7",
+        "run-async": "2.3.0",
+        "rx-lite": "4.0.8",
+        "rx-lite-aggregates": "4.0.8",
+        "string-width": "2.1.1",
+        "strip-ansi": "4.0.0",
+        "through": "2.3.8"
+      }
+    },
+    "insert-module-globals": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-7.0.1.tgz",
+      "integrity": "sha1-wDv04BywhtW15azorQr+eInWOMM=",
+      "requires": {
+        "combine-source-map": "0.7.2",
+        "concat-stream": "1.5.2",
+        "is-buffer": "1.1.5",
+        "JSONStream": "1.3.1",
+        "lexical-scope": "1.2.0",
+        "process": "0.11.10",
+        "through2": "2.0.3",
+        "xtend": "4.0.1"
+      }
+    },
+    "intent-utterance-expander": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/intent-utterance-expander/-/intent-utterance-expander-0.0.6.tgz",
+      "integrity": "sha1-BHEMuivMJRX/JZsoJa3/C2a8ptw="
+    },
+    "is-absolute": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.2.6.tgz",
+      "integrity": "sha1-IN5p89uULvLYe5wto28XIjWxtes=",
+      "requires": {
+        "is-relative": "0.2.1",
+        "is-windows": "0.2.0"
+      },
+      "dependencies": {
+        "is-windows": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
+          "integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw="
+        }
+      }
+    },
+    "is-alphabetical": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.1.tgz",
+      "integrity": "sha1-x3B5zJHU76x3W+EDS/LSQ/lebwg=",
+      "dev": true
+    },
+    "is-alphanumerical": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.1.tgz",
+      "integrity": "sha1-37SqTRCF4zvbYcLe6cgOnGwZ9Ts=",
+      "dev": true,
+      "requires": {
+        "is-alphabetical": "1.0.1",
+        "is-decimal": "1.0.1"
+      }
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
+    "is-buffer": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+      "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw="
+    },
+    "is-builtin-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+      "dev": true,
+      "requires": {
+        "builtin-modules": "1.1.1"
+      }
+    },
+    "is-decimal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.1.tgz",
+      "integrity": "sha1-9ftqlJlq2ejjdh+/vQkfH8qMToI=",
+      "dev": true
+    },
+    "is-dotdir": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-dotdir/-/is-dotdir-0.1.0.tgz",
+      "integrity": "sha1-2h5UZPWfw6g8HYIrWs4JG0X+azE=",
+      "requires": {
+        "dotdir-regex": "0.1.0"
+      }
+    },
+    "is-dotfile": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
+    },
+    "is-equal-shallow": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+      "requires": {
+        "is-primitive": "2.0.0"
+      }
+    },
+    "is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+    },
+    "is-extglob": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+    },
+    "is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
+    },
+    "is-glob": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+      "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+      "requires": {
+        "is-extglob": "1.0.0"
+      }
+    },
+    "is-hexadecimal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.1.tgz",
+      "integrity": "sha1-bghLvJIGH7sJcexYts5tQE4k2mk=",
+      "dev": true
+    },
+    "is-number": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+      "requires": {
+        "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "1.1.5"
+          }
+        }
+      }
+    },
+    "is-path-cwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+      "dev": true
+    },
+    "is-path-in-cwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+      "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+      "dev": true,
+      "requires": {
+        "is-path-inside": "1.0.0"
+      }
+    },
+    "is-path-inside": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
+      "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
+      "dev": true,
+      "requires": {
+        "path-is-inside": "1.0.2"
+      }
+    },
+    "is-posix-bracket": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
+    },
+    "is-primitive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
+    },
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "dev": true
+    },
+    "is-relative": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.2.1.tgz",
+      "integrity": "sha1-0n9MfVFtF1+2ENuEu+7yPDvJeqU=",
+      "requires": {
+        "is-unc-path": "0.1.2"
+      }
+    },
+    "is-resolvable": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
+      "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
+      "dev": true,
+      "requires": {
+        "tryit": "1.0.3"
+      }
+    },
+    "is-unc-path": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.2.tgz",
+      "integrity": "sha1-arBTpyVzwQJQ/0FqOBTDUXivObk=",
+      "requires": {
+        "unc-path-regex": "0.1.2"
+      }
+    },
+    "is-windows": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.1.1.tgz",
+      "integrity": "sha1-vjEHFUMc+rzMVKs5USEPoLbQGr4="
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+    },
+    "isobject": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+      "requires": {
+        "isarray": "1.0.0"
+      }
+    },
+    "jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=",
+      "dev": true
+    },
+    "js-tokens": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
+      "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+      "requires": {
+        "argparse": "1.0.9",
+        "esprima": "4.0.0"
+      }
+    },
+    "jschardet": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.5.1.tgz",
+      "integrity": "sha512-vE2hT1D0HLZCLLclfBSfkfTTedhVj0fubHpJBHKwwUWX0nSbhPAfk+SG9rTX95BYNmau8rGFfCeaT6T5OW1C2A==",
+      "dev": true
+    },
+    "json-schema-traverse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+      "dev": true
+    },
+    "json-stable-stringify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
+      "integrity": "sha1-YRwj6BTbN1Un34URk9tZ3Sryf0U=",
+      "requires": {
+        "jsonify": "0.0.0"
+      }
+    },
+    "json3": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
+      "dev": true
+    },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+    },
+    "jsonparse": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
+    },
+    "JSONStream": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
+      "requires": {
+        "jsonparse": "1.3.1",
+        "through": "2.3.8"
+      }
+    },
+    "kind-of": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+      "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
+      "requires": {
+        "is-buffer": "1.1.5"
+      }
+    },
+    "labeled-stream-splicer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-2.0.0.tgz",
+      "integrity": "sha1-pS4dE4AkwAuGscDJH2d5GLiuClk=",
+      "requires": {
+        "inherits": "2.0.3",
+        "isarray": "0.0.1",
+        "stream-splicer": "2.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        }
+      }
+    },
+    "lazy-cache": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.1.0.tgz",
+      "integrity": "sha1-1s1FAlHUFbcBA3ZfYxMKAEmgN5U=",
+      "requires": {
+        "ansi-yellow": "0.1.1"
+      }
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
+      }
+    },
+    "lexical-scope": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.2.0.tgz",
+      "integrity": "sha1-/Ope3HBKSzqHls3KQZw6CvryLfQ=",
+      "requires": {
+        "astw": "2.2.0"
+      }
+    },
+    "load-json-file": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+      "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "parse-json": "2.2.0",
+        "pify": "2.3.0",
+        "strip-bom": "3.0.0"
+      }
+    },
+    "locate-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "dev": true,
+      "requires": {
+        "p-locate": "2.0.0",
+        "path-exists": "3.0.0"
+      },
+      "dependencies": {
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        }
+      }
+    },
+    "lodash": {
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+    },
+    "lodash._baseassign": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+      "dev": true,
+      "requires": {
+        "lodash._basecopy": "3.0.1",
+        "lodash.keys": "3.1.2"
+      }
+    },
+    "lodash._basecopy": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+      "dev": true
+    },
+    "lodash._basecreate": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+      "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
+      "dev": true
+    },
+    "lodash._getnative": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+      "dev": true
+    },
+    "lodash._isiterateecall": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+      "dev": true
+    },
+    "lodash.cond": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/lodash.cond/-/lodash.cond-4.5.2.tgz",
+      "integrity": "sha1-9HGh2khr5g9quVXRcRVSPdHSVdU=",
+      "dev": true
+    },
+    "lodash.create": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
+      "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
+      "dev": true,
+      "requires": {
+        "lodash._baseassign": "3.2.0",
+        "lodash._basecreate": "3.0.3",
+        "lodash._isiterateecall": "3.0.9"
+      }
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+      "dev": true
+    },
+    "lodash.isarray": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+      "dev": true
+    },
+    "lodash.keys": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "dev": true,
+      "requires": {
+        "lodash._getnative": "3.9.1",
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
+      }
+    },
+    "lodash.memoize": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
+      "integrity": "sha1-LcvSwofLwKVcxCMovQxzYVDVPj8="
+    },
+    "longest-streak": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-1.0.0.tgz",
+      "integrity": "sha1-0GWXxNTDG1LMsfXY+P5xSOr9aWU=",
+      "dev": true
+    },
+    "lower-case": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
+      "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw="
+    },
+    "lru-cache": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+      "dev": true,
+      "requires": {
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
+      }
+    },
+    "map-cache": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
+    },
+    "markdown-table": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-0.4.0.tgz",
+      "integrity": "sha1-iQwsGzv+g/sA5BKbjkz+ZFJw+dE=",
+      "dev": true
+    },
+    "markdown-to-ast": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/markdown-to-ast/-/markdown-to-ast-3.4.0.tgz",
+      "integrity": "sha1-Diy6gTkLBUmpFT7DsNkVthwWS+c=",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "remark": "5.1.0",
+        "structured-source": "3.0.2",
+        "traverse": "0.6.6"
+      }
+    },
+    "md5": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
+      "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
+      "requires": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "1.1.5"
+      }
+    },
+    "md5.js": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
+      "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
+      "requires": {
+        "hash-base": "3.0.4",
+        "inherits": "2.0.3"
+      },
+      "dependencies": {
+        "hash-base": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
+          "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+          "requires": {
+            "inherits": "2.0.3",
+            "safe-buffer": "5.1.1"
+          }
+        }
+      }
+    },
+    "micromatch": {
+      "version": "github:jonschlinkert/micromatch#b0ac0b7cea8d90f97630c027d0116a8aef06bfdc",
+      "requires": {
+        "arr-diff": "1.1.0",
+        "array-unique": "0.2.1",
+        "braces": "1.8.5",
+        "expand-brackets": "0.1.5",
+        "extglob": "0.3.2",
+        "filename-regex": "2.0.1",
+        "is-glob": "1.1.3",
+        "kind-of": "1.1.0",
+        "object.omit": "1.1.0",
+        "parse-glob": "3.0.4",
+        "regex-cache": "0.4.4"
+      },
+      "dependencies": {
+        "arr-diff": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
+          "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
+          "requires": {
+            "arr-flatten": "1.1.0",
+            "array-slice": "0.2.3"
+          }
+        },
+        "is-glob": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-1.1.3.tgz",
+          "integrity": "sha1-tMZLgwPTkRRJKkYNNkzPsNPAoEU="
+        },
+        "kind-of": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+          "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ="
+        }
+      }
+    },
+    "miller-rabin": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
+      "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+      "requires": {
+        "bn.js": "4.11.8",
+        "brorand": "1.1.0"
+      }
+    },
+    "mimic-fn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
+      "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
+      "dev": true
+    },
+    "minimalistic-assert": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
+      "integrity": "sha1-cCvi3aazf0g2vLP121ZkG2Sh09M="
+    },
+    "minimalistic-crypto-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "1.1.8"
+      }
+    },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+    },
+    "mixin-object": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mixin-object/-/mixin-object-2.0.1.tgz",
+      "integrity": "sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=",
+      "requires": {
+        "for-in": "0.1.8",
+        "is-extendable": "0.1.1"
+      },
+      "dependencies": {
+        "for-in": {
+          "version": "0.1.8",
+          "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz",
+          "integrity": "sha1-2Hc5COMSVhCZUrH9ubP6hn0ndeE="
+        }
+      }
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        }
+      }
+    },
+    "mocha": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
+      "integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.9.0",
+        "debug": "2.6.8",
+        "diff": "3.2.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.1",
+        "growl": "1.9.2",
+        "he": "1.1.1",
+        "json3": "3.3.2",
+        "lodash.create": "3.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "3.1.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.8",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+          "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "has-flag": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+          "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+          "dev": true,
+          "requires": {
+            "has-flag": "1.0.0"
+          }
+        }
+      }
+    },
+    "module-deps": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-4.1.1.tgz",
+      "integrity": "sha1-IyFYM/HaE/1gbMuAh7RIUty4If0=",
+      "requires": {
+        "browser-resolve": "1.11.2",
+        "cached-path-relative": "1.0.1",
+        "concat-stream": "1.5.2",
+        "defined": "1.0.0",
+        "detective": "4.5.0",
+        "duplexer2": "0.1.4",
+        "inherits": "2.0.3",
+        "JSONStream": "1.3.1",
+        "parents": "1.0.1",
+        "readable-stream": "2.3.3",
+        "resolve": "1.4.0",
+        "stream-combiner2": "1.1.1",
+        "subarg": "1.0.0",
+        "through2": "2.0.3",
+        "xtend": "4.0.1"
+      }
+    },
+    "moment": {
+      "version": "2.18.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
+      "integrity": "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8="
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "mute-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+      "dev": true
+    },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
+    "no-case": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
+      "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
+      "requires": {
+        "lower-case": "1.1.4"
+      }
+    },
+    "node-config-yml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/node-config-yml/-/node-config-yml-1.0.1.tgz",
+      "integrity": "sha1-/dPWZIvUfBbf8K9QYKVwVdmpzlw=",
+      "requires": {
+        "js-yaml": "2.1.0"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "0.1.16",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
+          "integrity": "sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=",
+          "requires": {
+            "underscore": "1.7.0",
+            "underscore.string": "2.4.0"
+          }
+        },
+        "esprima": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+          "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0="
+        },
+        "js-yaml": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.1.0.tgz",
+          "integrity": "sha1-pVpuRwawHQYyYlmm9L/ELmrjix8=",
+          "requires": {
+            "argparse": "0.1.16",
+            "esprima": "1.0.4"
+          }
+        }
+      }
+    },
+    "noncharacters": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/noncharacters/-/noncharacters-1.1.0.tgz",
+      "integrity": "sha1-rzPfMP1Q7TxTzSAiWPJa2pC1QNI="
+    },
+    "normalize-package-data": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "2.5.0",
+        "is-builtin-module": "1.0.0",
+        "semver": "5.4.1",
+        "validate-npm-package-license": "3.0.1"
+      }
+    },
+    "normalize-path": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+      "requires": {
+        "remove-trailing-separator": "1.1.0"
+      }
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
+    },
+    "object-visit": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-0.1.0.tgz",
+      "integrity": "sha1-sbtnSfIo7nbgxC84UdKKFNIzziY=",
+      "requires": {
+        "isobject": "1.0.2"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-1.0.2.tgz",
+          "integrity": "sha1-8Pm4zpLdVA+gdAiC44NaLgIux4o="
+        }
+      }
+    },
+    "object.omit": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-1.1.0.tgz",
+      "integrity": "sha1-nRfqFneOUFfeundSxvVfFJaCnpQ=",
+      "requires": {
+        "for-own": "0.1.5",
+        "isobject": "1.0.2"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-1.0.2.tgz",
+          "integrity": "sha1-8Pm4zpLdVA+gdAiC44NaLgIux4o="
+        }
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "onetime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "1.1.0"
+      }
+    },
+    "optionator": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "dev": true,
+      "requires": {
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
+      }
+    },
+    "os-browserify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz",
+      "integrity": "sha1-ScoCk+CxlZCl9d4Qx/JlphfY/lQ="
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
+    },
+    "p-limit": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
+      "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
+      "dev": true
+    },
+    "p-locate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "dev": true,
+      "requires": {
+        "p-limit": "1.1.0"
+      }
+    },
+    "pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU="
+    },
+    "parents": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
+      "integrity": "sha1-/t1NK/GTp3dF/nHjcdc8MwfZx1E=",
+      "requires": {
+        "path-platform": "0.11.15"
+      }
+    },
+    "parse-asn1": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
+      "integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
+      "requires": {
+        "asn1.js": "4.9.1",
+        "browserify-aes": "1.0.8",
+        "create-hash": "1.1.3",
+        "evp_bytestokey": "1.0.3",
+        "pbkdf2": "3.0.14"
+      }
+    },
+    "parse-entities": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.1.1.tgz",
+      "integrity": "sha1-gRLYhHExnyerrk1klksSL+ThuJA=",
+      "dev": true,
+      "requires": {
+        "character-entities": "1.2.1",
+        "character-entities-legacy": "1.1.1",
+        "character-reference-invalid": "1.1.1",
+        "is-alphanumerical": "1.0.1",
+        "is-decimal": "1.0.1",
+        "is-hexadecimal": "1.0.1"
+      }
+    },
+    "parse-filepath": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-0.6.3.tgz",
+      "integrity": "sha1-OOF6c+Xk5ndrrpUG/DzLFLw6K4A=",
+      "requires": {
+        "is-absolute": "0.2.6",
+        "map-cache": "0.2.2"
+      }
+    },
+    "parse-gitignore": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/parse-gitignore/-/parse-gitignore-0.2.0.tgz",
+      "integrity": "sha1-mHBtCfD5PuhjSLch/+4GBrwJPXQ=",
+      "requires": {
+        "ends-with": "0.2.0",
+        "is-glob": "2.0.1",
+        "starts-with": "1.0.2"
+      }
+    },
+    "parse-glob": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+      "requires": {
+        "glob-base": "0.3.0",
+        "is-dotfile": "1.0.3",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1"
+      }
+    },
+    "parse-json": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "dev": true,
+      "requires": {
+        "error-ex": "1.3.1"
+      }
+    },
+    "parse-passwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+      "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
+    },
+    "parse-uri": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parse-uri/-/parse-uri-1.0.0.tgz",
+      "integrity": "sha1-KHLcwi8aeXrN4Vg9igrClVLdrCA="
+    },
+    "pascal-case": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-2.0.1.tgz",
+      "integrity": "sha1-LVeNNFX2YNpl7KGO+VtODekSdh4=",
+      "requires": {
+        "camel-case": "3.0.0",
+        "upper-case-first": "1.1.2"
+      }
+    },
+    "path-browserify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
+      "integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo="
+    },
+    "path-exists": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+      "dev": true,
+      "requires": {
+        "pinkie-promise": "2.0.1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
+    },
+    "path-platform": {
+      "version": "0.11.15",
+      "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz",
+      "integrity": "sha1-6GQhf3TDaFDwhSt43Hv31KVyG/I="
+    },
+    "path-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+      "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+      "dev": true,
+      "requires": {
+        "pify": "2.3.0"
+      }
+    },
+    "pbkdf2": {
+      "version": "3.0.14",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.14.tgz",
+      "integrity": "sha512-gjsZW9O34fm0R7PaLHRJmLLVfSoesxztjPjE9o6R+qtVJij90ltg1joIovN9GKrRW3t1PzhDDG3UMEMFfZ+1wA==",
+      "requires": {
+        "create-hash": "1.1.3",
+        "create-hmac": "1.1.6",
+        "ripemd160": "2.0.1",
+        "safe-buffer": "5.1.1",
+        "sha.js": "2.4.9"
+      }
+    },
+    "pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "dev": true
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
+      "requires": {
+        "pinkie": "2.0.4"
+      }
+    },
+    "pkg-dir": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
+      "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
+      "dev": true,
+      "requires": {
+        "find-up": "1.1.2"
+      }
+    },
+    "pluck": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/pluck/-/pluck-0.0.4.tgz",
+      "integrity": "sha1-VU9Uwo2QPMyCOej3j2gtkAC0pxI="
+    },
+    "pluralize": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+      "dev": true
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "preserve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
+    },
+    "process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
+    },
+    "process-nextick-args": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+    },
+    "progress": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
+      "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
+      "dev": true
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
+    },
+    "public-encrypt": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
+      "integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=",
+      "requires": {
+        "bn.js": "4.11.8",
+        "browserify-rsa": "4.0.1",
+        "create-hash": "1.1.3",
+        "parse-asn1": "5.1.0",
+        "randombytes": "2.0.5"
+      }
+    },
+    "punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+    },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+    },
+    "querystring-es3": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+      "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
+    },
+    "randomatic": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+      "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+      "requires": {
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "requires": {
+                "is-buffer": "1.1.5"
+              }
+            }
+          }
+        },
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "requires": {
+            "is-buffer": "1.1.5"
+          }
+        }
+      }
+    },
+    "randombytes": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz",
+      "integrity": "sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg==",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "read-only-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/read-only-stream/-/read-only-stream-2.0.0.tgz",
+      "integrity": "sha1-JyT9aoET1zdkrCiNQ4YnDB2/F/A=",
+      "requires": {
+        "readable-stream": "2.3.3"
+      }
+    },
+    "read-pkg": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+      "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+      "dev": true,
+      "requires": {
+        "load-json-file": "2.0.0",
+        "normalize-package-data": "2.4.0",
+        "path-type": "2.0.0"
+      }
+    },
+    "read-pkg-up": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+      "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+      "dev": true,
+      "requires": {
+        "find-up": "2.1.0",
+        "read-pkg": "2.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "2.0.0"
+          }
+        }
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "1.0.7",
+        "safe-buffer": "5.1.1",
+        "string_decoder": "1.0.3",
+        "util-deprecate": "1.0.2"
+      }
+    },
+    "regex-cache": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+      "requires": {
+        "is-equal-shallow": "0.1.3"
+      }
+    },
+    "relative": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/relative/-/relative-3.0.2.tgz",
+      "integrity": "sha1-Dc2OxUpdNaPBXhBFA9ZTdbWlNn8=",
+      "requires": {
+        "isobject": "2.1.0"
+      }
+    },
+    "remark": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/remark/-/remark-5.1.0.tgz",
+      "integrity": "sha1-y0Y709vLS5l5STXu4c9x16jjBow=",
+      "dev": true,
+      "requires": {
+        "remark-parse": "1.1.0",
+        "remark-stringify": "1.1.0",
+        "unified": "4.2.1"
+      }
+    },
+    "remark-parse": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-1.1.0.tgz",
+      "integrity": "sha1-w8oQ+ajaBGFcKPCapOMEUQUm7CE=",
+      "dev": true,
+      "requires": {
+        "collapse-white-space": "1.0.3",
+        "extend": "3.0.1",
+        "parse-entities": "1.1.1",
+        "repeat-string": "1.6.1",
+        "trim": "0.0.1",
+        "trim-trailing-lines": "1.1.0",
+        "unherit": "1.1.0",
+        "unist-util-remove-position": "1.1.1",
+        "vfile-location": "2.0.2"
+      }
+    },
+    "remark-stringify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-1.1.0.tgz",
+      "integrity": "sha1-pxBeJbnuK/mkm3XSxCPxGwauIJI=",
+      "dev": true,
+      "requires": {
+        "ccount": "1.0.2",
+        "extend": "3.0.1",
+        "longest-streak": "1.0.0",
+        "markdown-table": "0.4.0",
+        "parse-entities": "1.1.1",
+        "repeat-string": "1.6.1",
+        "stringify-entities": "1.3.1",
+        "unherit": "1.1.0"
+      }
+    },
+    "remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+    },
+    "repeat-element": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+    },
+    "require-uncached": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+      "dev": true,
+      "requires": {
+        "caller-path": "0.1.0",
+        "resolve-from": "1.0.1"
+      }
+    },
+    "resolve": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
+      "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
+      "requires": {
+        "path-parse": "1.0.5"
+      }
+    },
+    "resolve-dir": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
+      "integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
+      "requires": {
+        "expand-tilde": "1.2.2",
+        "global-modules": "0.2.3"
+      }
+    },
+    "resolve-from": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+      "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+      "dev": true
+    },
+    "restore-cursor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "dev": true,
+      "requires": {
+        "onetime": "2.0.1",
+        "signal-exit": "3.0.2"
+      }
+    },
+    "rimraf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2"
+      }
+    },
+    "ripemd160": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
+      "integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
+      "requires": {
+        "hash-base": "2.0.2",
+        "inherits": "2.0.3"
+      }
+    },
+    "run-async": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+      "dev": true,
+      "requires": {
+        "is-promise": "2.1.0"
+      }
+    },
+    "rx-lite": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
+      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
+      "dev": true
+    },
+    "rx-lite-aggregates": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
+      "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+      "dev": true,
+      "requires": {
+        "rx-lite": "4.0.8"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+    },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
+    "semver": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+      "dev": true
+    },
+    "set-value": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.2.0.tgz",
+      "integrity": "sha1-c7CmglwVjGoWqCu9yVd1vyqCX6s=",
+      "requires": {
+        "isobject": "1.0.2",
+        "noncharacters": "1.1.0"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-1.0.2.tgz",
+          "integrity": "sha1-8Pm4zpLdVA+gdAiC44NaLgIux4o="
+        }
+      }
+    },
+    "sha.js": {
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.9.tgz",
+      "integrity": "sha512-G8zektVqbiPHrylgew9Zg1VRB1L/DtXNUVAM6q4QLy8NE3qtHlFXTf8VLL4k1Yl6c7NMjtZUTdXV+X44nFaT6A==",
+      "requires": {
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "shasum": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
+      "integrity": "sha1-5wEjENj0F/TetXEhUOVni4euVl8=",
+      "requires": {
+        "json-stable-stringify": "0.0.1",
+        "sha.js": "2.4.9"
+      }
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
+    "shell-quote": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
+      "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
+      "requires": {
+        "array-filter": "0.0.1",
+        "array-map": "0.0.0",
+        "array-reduce": "0.0.0",
+        "jsonify": "0.0.0"
+      }
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
+    },
+    "slice-ansi": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "2.0.0"
+      }
+    },
+    "source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+    },
+    "spdx-correct": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+      "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+      "dev": true,
+      "requires": {
+        "spdx-license-ids": "1.2.2"
+      }
+    },
+    "spdx-expression-parse": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+      "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
+      "dev": true
+    },
+    "spdx-license-ids": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
+      "dev": true
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+    },
+    "ssml-validator": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/ssml-validator/-/ssml-validator-0.1.0.tgz",
+      "integrity": "sha1-7sia22ZzSSm2J2eFC1sTxLHyuQw="
+    },
+    "starts-with": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/starts-with/-/starts-with-1.0.2.tgz",
+      "integrity": "sha1-Fnk6cp2J1M89T7LtovkIrjV/GW8="
+    },
+    "stream-browserify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
+      "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3"
+      }
+    },
+    "stream-combiner2": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
+      "integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
+      "requires": {
+        "duplexer2": "0.1.4",
+        "readable-stream": "2.3.3"
+      }
+    },
+    "stream-http": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.2.tgz",
+      "integrity": "sha512-c0yTD2rbQzXtSsFSVhtpvY/vS6u066PcXOX9kBB3mSO76RiUQzL340uJkGBWnlBg4/HZzqiUXtaVA7wcRcJgEw==",
+      "requires": {
+        "builtin-status-codes": "3.0.0",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3",
+        "to-arraybuffer": "1.0.1",
+        "xtend": "4.0.1"
+      }
+    },
+    "stream-splicer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-2.0.0.tgz",
+      "integrity": "sha1-G2O+Q4oTPktnHMGTUZdgAXWRDYM=",
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "2.0.0",
+        "strip-ansi": "4.0.0"
+      }
+    },
+    "stringify-entities": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-1.3.1.tgz",
+      "integrity": "sha1-sVDsLXKsTBtfMktR+2soyc3/BYw=",
+      "dev": true,
+      "requires": {
+        "character-entities-html4": "1.1.1",
+        "character-entities-legacy": "1.1.1",
+        "is-alphanumerical": "1.0.1",
+        "is-hexadecimal": "1.0.1"
+      }
+    },
+    "strip-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "3.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        }
+      }
+    },
+    "strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true
+    },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true
+    },
+    "structured-source": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/structured-source/-/structured-source-3.0.2.tgz",
+      "integrity": "sha1-3YAkJeD1PcSm56yjdSkBoczaevU=",
+      "dev": true,
+      "requires": {
+        "boundary": "1.0.1"
+      }
+    },
+    "subarg": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
+      "integrity": "sha1-9izxdYHplrSPyWVpn1TAauJouNI=",
+      "requires": {
+        "minimist": "1.2.0"
+      }
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "dev": true
+    },
+    "syntax-error": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.3.0.tgz",
+      "integrity": "sha1-HtkmbE1AvnXcVb+bsct3Biu5bKE=",
+      "requires": {
+        "acorn": "4.0.13"
+      }
+    },
+    "table": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
+      "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+      "dev": true,
+      "requires": {
+        "ajv": "5.2.3",
+        "ajv-keywords": "2.1.0",
+        "chalk": "2.1.0",
+        "lodash": "4.17.4",
+        "slice-ansi": "1.0.0",
+        "string-width": "2.1.1"
+      }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+    },
+    "through2": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+      "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+      "requires": {
+        "readable-stream": "2.3.3",
+        "xtend": "4.0.1"
+      }
+    },
+    "timers-browserify": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
+      "integrity": "sha1-ycWLV1voQHN1y14kYtrO50NZ9B0=",
+      "requires": {
+        "process": "0.11.10"
+      }
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "1.0.2"
+      }
+    },
+    "to-arraybuffer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
+      "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M="
+    },
+    "traverse": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
+      "dev": true
+    },
+    "trim": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
+      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0=",
+      "dev": true
+    },
+    "trim-trailing-lines": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.0.tgz",
+      "integrity": "sha1-eu+7eAjfnWafbaLkOMrIxGradoQ=",
+      "dev": true
+    },
+    "trough": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.1.tgz",
+      "integrity": "sha1-qf2LA5Swro//guBjOgo2zK1bX4Y=",
+      "dev": true
+    },
+    "tryit": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
+      "integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=",
+      "dev": true
+    },
+    "tty-browserify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+      "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY="
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2"
+      }
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    },
+    "umd": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.1.tgz",
+      "integrity": "sha1-iuVW4RAR9jwllnCKiDclnwGz1g4="
+    },
+    "unc-path-regex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
+      "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo="
+    },
+    "underscore": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+      "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk="
+    },
+    "underscore.string": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
+      "integrity": "sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs="
+    },
+    "unherit": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.0.tgz",
+      "integrity": "sha1-a5qu379z3xdWrZ4xbdmBiFhAzX0=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "xtend": "4.0.1"
+      }
+    },
+    "unified": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-4.2.1.tgz",
+      "integrity": "sha1-dv9Dqo2kMPbn5KVchOusKtLPzS4=",
+      "dev": true,
+      "requires": {
+        "bail": "1.0.2",
+        "extend": "3.0.1",
+        "has": "1.0.1",
+        "once": "1.4.0",
+        "trough": "1.0.1",
+        "vfile": "1.4.0"
+      }
+    },
+    "unist-util-remove-position": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.1.tgz",
+      "integrity": "sha1-WoXBVV/BugwQG4ZwfRXlD6TIcbs=",
+      "dev": true,
+      "requires": {
+        "unist-util-visit": "1.1.3"
+      }
+    },
+    "unist-util-visit": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.1.3.tgz",
+      "integrity": "sha1-7CaOcxudJ3p5pbWqBkOZDkBdYAs=",
+      "dev": true
+    },
+    "update-section": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/update-section/-/update-section-0.3.3.tgz",
+      "integrity": "sha1-RY8Xgg03gg3GDiC4bZQ5GwASMVg=",
+      "dev": true
+    },
+    "upper-case": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
+      "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg="
+    },
+    "upper-case-first": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.2.tgz",
+      "integrity": "sha1-XXm+3P8UQZUY/S7bCgUHybaFkRU=",
+      "requires": {
+        "upper-case": "1.1.3"
+      }
+    },
+    "url": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+      "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+        }
+      }
+    },
+    "util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+      "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+      "requires": {
+        "inherits": "2.0.1"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+        }
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "uuid": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
+      "dev": true
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+      "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+      "dev": true,
+      "requires": {
+        "spdx-correct": "1.0.2",
+        "spdx-expression-parse": "1.0.4"
+      }
+    },
+    "vfile": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-1.4.0.tgz",
+      "integrity": "sha1-wP1vpIT43r23cfaMMe112I2pf+c=",
+      "dev": true
+    },
+    "vfile-location": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.2.tgz",
+      "integrity": "sha1-02dcWch3SY5JK0dW/2Xkrxp1IlU=",
+      "dev": true
+    },
+    "vm-browserify": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+      "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
+      "requires": {
+        "indexof": "0.0.1"
+      }
+    },
+    "which": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+      "requires": {
+        "isexe": "2.0.0"
+      }
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "write": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+      "dev": true,
+      "requires": {
+        "mkdirp": "0.5.1"
+      }
+    },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "requires": {
+        "sax": "1.2.4",
+        "xmlbuilder": "9.0.4"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.4.tgz",
+      "integrity": "sha1-UZy0ymhtAFqEINNJbz8MruzKWA8="
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "dev": true
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -646,6 +646,12 @@
         "moment": "2.18.1"
       }
     },
+    "ci-info": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.1.tgz",
+      "integrity": "sha512-vHDDF/bP9RYpTWtUhpJRhCFdvvp3iDWvEbuDbWgvjUrNGV1MXJrE0MPcwGtEled04m61iwdBLUIHZtDgzWS4ZQ==",
+      "dev": true
+    },
     "cipher-base": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
@@ -1862,6 +1868,25 @@
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
     },
+    "husky": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-0.14.3.tgz",
+      "integrity": "sha512-e21wivqHpstpoiWA/Yi8eFti8E+sQDSS53cpJsPptPs295QTOQR0ZwnHo2TXy1XOpZFD9rPOd3NpmqTK6uMLJA==",
+      "dev": true,
+      "requires": {
+        "is-ci": "1.0.10",
+        "normalize-path": "1.0.0",
+        "strip-indent": "2.0.0"
+      },
+      "dependencies": {
+        "normalize-path": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-1.0.0.tgz",
+          "integrity": "sha1-MtDkcvkf80VwHBWoMRAY07CpA3k=",
+          "dev": true
+        }
+      }
+    },
     "iconv-lite": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
@@ -2009,6 +2034,15 @@
       "dev": true,
       "requires": {
         "builtin-modules": "1.1.1"
+      }
+    },
+    "is-ci": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz",
+      "integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
+      "dev": true,
+      "requires": {
+        "ci-info": "1.1.1"
       }
     },
     "is-decimal": {
@@ -3591,6 +3625,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true
+    },
+    "strip-indent": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+      "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
       "dev": true
     },
     "strip-json-comments": {

--- a/package.json
+++ b/package.json
@@ -1,17 +1,35 @@
 {
   "name": "skills-in-pills",
   "version": "0.0.5",
-  "description": "A more fun way to build skills for Alexa.",
-  "main": "index.js",
+  "description": "A more fun way to build skills for Alexa",
+  "license": "MIT",
+  "engines": {
+    "node": ">=6",
+    "npm": ">=5",
+    "yarn": ">=1"
+  },
+  "repository": "Ravenstine/skills-in-pills",
+  "author": {
+    "email": "btitcomb@scpr.org",
+    "name": "Ben Titcomb"
+  },
   "bin": {
     "skills-in-pills": "./bin/skills-in-pills"
   },
+  "main": "index.js",
   "scripts": {
-    "test": "mocha",
-    "proxy": "bst proxy lambda index.js"
+    "precommit": "./node_modules/.bin/doctoc README.md &&  && npm test",
+    "proxy": "bst proxy lambda index.js",
+    "test": "./node_modules/.bin/eslint lib/*.js bin/*.js index.js && mocha",
+    "test2": "mocha"
   },
-  "author": "Ben Titcomb",
-  "license": "MIT",
+  "keywords": [
+    "alexa",
+    "echo-dot",
+    "amazon-echo",
+    "amazon-alexa-skill",
+    "voice-activated"
+  ],
   "dependencies": {
     "browserify": "^14.4.0",
     "camelize": "^1.0.0",
@@ -35,6 +53,10 @@
   },
   "devDependencies": {
     "aws-sdk": "^2.100.0",
+    "doctoc": "^1.3.0",
+    "eslint": "^4.8.0",
+    "eslint-config-airbnb-base": "^12.0.2",
+    "eslint-plugin-import": "^2.7.0",
     "mocha": "^3.4.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "main": "index.js",
   "scripts": {
-    "precommit": "./node_modules/.bin/doctoc README.md &&  && npm test",
+    "precommit": "./node_modules/.bin/doctoc README.md && npm test",
     "proxy": "bst proxy lambda index.js",
     "test": "./node_modules/.bin/eslint lib/*.js bin/*.js index.js && mocha",
     "test2": "mocha"
@@ -57,6 +57,7 @@
     "eslint": "^4.8.0",
     "eslint-config-airbnb-base": "^12.0.2",
     "eslint-plugin-import": "^2.7.0",
+    "husky": "^0.14.3",
     "mocha": "^3.4.2"
   }
 }

--- a/test/assign.test.js
+++ b/test/assign.test.js
@@ -1,10 +1,8 @@
-'use strict';
+const assert = require('assert');
+const assign = require('../lib/builders/assign');
 
-const assert  = require('assert');
-const assign  = require('../lib/builders/assign');
-
-describe('operators', function(){
-  let context = {
+describe('operators', () => {
+  const context = {
     attributes: {
       setTest: undefined,
       setTest1: undefined,
@@ -12,150 +10,148 @@ describe('operators', function(){
       stringTest: 'hello',
       numberTest: 0,
       stringNumberTest: '3',
-      arrayTest: [1,2,3],
+      arrayTest: [1, 2, 3],
       objectTest: {},
       dateTest: undefined,
       nullText: null,
       eraseTest: 'erase me!',
       expressionTest: undefined,
-      booleanTest: undefined
+      booleanTest: undefined,
     },
     slots: {
-      foo: 'bar'
-    }
+      foo: 'bar',
+    },
   };
 
-  it('sets a boolean', function(){
+  it('sets a boolean', () => {
     assign(context.attributes, {
       set: {
-        booleanTest: true
-      }
+        booleanTest: true,
+      },
     }, context);
     assert.equal(context.attributes.booleanTest, true);
-  })
+  });
 
-  it('sets a multiple values', function(){
+  it('sets a multiple values', () => {
     assign(context.attributes, {
       set: {
         setTest1: 'a',
-        setTest2: 'b'
-      }
+        setTest2: 'b',
+      },
     }, context);
-    assert.equal(context.attributes.setTest1 == 'a', true);
-    assert.equal(context.attributes.setTest2 == 'b', true);
-  })
+    assert.equal(context.attributes.setTest1 === 'a', true);
+    assert.equal(context.attributes.setTest2 === 'b', true);
+  });
 
 
-  it('increments a number attribute', function(){
+  it('increments a number attribute', () => {
     assign(context.attributes, {
       increment: {
-        numberTest: 3
-      }
+        numberTest: 3,
+      },
     }, context);
     assert.equal(context.attributes.numberTest, 3);
   });
 
-  it('increments a string attribute', function(){
+  it('increments a string attribute', () => {
     assign(context.attributes, {
       increment: {
-        stringNumberTest: 4
-      }
+        stringNumberTest: 4,
+      },
     }, context);
     assert.equal(context.attributes.stringNumberTest, 7);
   });
 
-  it('increments a number attribute with a string', function(){
+  it('increments a number attribute with a string', () => {
     assign(context.attributes, {
       increment: {
-        numberTest: '2'
-      }
+        numberTest: '2',
+      },
     }, context);
     assert.equal(context.attributes.numberTest, 5);
   });
 
-  it('increments a non-zero attribute', function(){
+  it('increments a non-zero attribute', () => {
     assign(context.attributes, {
       increment: {
-        numberTest: 3
-      }
+        numberTest: 3,
+      },
     }, context);
     assert.equal(context.attributes.numberTest, 8);
   });
 
-  it('decrements an attribute', function(){
+  it('decrements an attribute', () => {
     assign(context.attributes, {
       increment: {
-        numberTest: -2
-      }
+        numberTest: -2,
+      },
     }, context);
     assert.equal(context.attributes.numberTest, 6);
   });
 
-  it('does not try to increment a non-number', function(){
-    let originalObject = context.attributes.objectTest;
+  it('does not try to increment a non-number', () => {
+    const originalObject = context.attributes.objectTest;
     assign(context.attributes, {
       increment: {
-        objectTest: -2
-      }
+        objectTest: -2,
+      },
     }, context);
     assert.equal(context.attributes.objectTest, originalObject);
   });
 
-  it('erases attributes', function(){
-    let originalObject = context.attributes.objectTest;
+  it('erases attributes', () => {
+    // const originalObject = context.attributes.objectTest;
     assign(context.attributes, {
       erase: {
-        eraseTest: undefined 
-      }
+        eraseTest: undefined,
+      },
     }, context);
     assert.equal(Object.keys(context.attributes).indexOf('eraseTest'), -1);
   });
 
-  it('appends items to an array', function(){
+  it('appends items to an array', () => {
     assign(context.attributes, {
       append: {
-        arrayTest: 4 
-      }
+        arrayTest: 4,
+      },
     }, context);
     assert.equal(context.attributes.arrayTest[context.attributes.arrayTest.length - 1], 4);
   });
 
-  it('prepends items to an array', function(){
+  it('prepends items to an array', () => {
     assign(context.attributes, {
       prepend: {
-        arrayTest: 5
-      }
+        arrayTest: 5,
+      },
     }, context);
     assert.equal(context.attributes.arrayTest[0], 5);
   });
 
-  it('can assign a date', function(){
+  it('can assign a date', () => {
     assign(context.attributes, {
       date: {
-        dateTest: 'today'
-      }
+        dateTest: 'today',
+      },
     }, context);
-    let isDate = Object.prototype.toString.call(context.attributes.dateTest) === '[object Date]';
+    const isDate = Object.prototype.toString.call(context.attributes.dateTest) === '[object Date]';
     assert.equal(isDate, true);
   });
 
-  it('can assign from an expression', function(){
+  it('can assign from an expression', () => {
     assign(context.attributes, {
       expression: {
-        expressionTest: '40 + 2'
-      }
+        expressionTest: '40 + 2',
+      },
     }, context);
     assert.equal(context.attributes.expressionTest, 42);
   });
 
-  it('can assign from an intent slot', function(){
+  it('can assign from an intent slot', () => {
     assign(context.attributes, {
       slot: {
-        baz: 'foo'
-      }
+        baz: 'foo',
+      },
     }, context);
     assert.equal(context.attributes.baz, 'bar');
   });
-
 });
-

--- a/test/card.test.js
+++ b/test/card.test.js
@@ -1,23 +1,19 @@
-'use strict';
+const assert = require('assert');
+const card = require('../lib/builders/card');
 
-const assert      = require('assert');
-const card  = require('../lib/builders/card');
-
-describe('operators', function(){
-  let context = {
+describe('operators', () => {
+  const context = {
     attributes: {
     },
     response: {
 
     },
-    responseBody: {}
+    responseBody: {},
   };
 
-  it('adds a simple card object to the response', function(){
-    let cardInput = {title: "hello", content: "hello world"};
+  it('adds a simple card object to the response', () => {
+    const cardInput = { title: 'hello', content: 'hello world' };
     card(cardInput, context);
-    assert.deepEqual({type: "Simple", title: "hello", content: "hello world"}, context.responseBody.card);
+    assert.deepEqual({ type: 'Simple', title: 'hello', content: 'hello world' }, context.responseBody.card);
   });
-  
 });
-

--- a/test/condition.test.js
+++ b/test/condition.test.js
@@ -1,27 +1,22 @@
-'use strict';
-
-const assert          = require('assert');
-const condition       = require('../lib/builders/condition');
+const assert = require('assert');
+const condition = require('../lib/builders/condition');
 const generateContext = require('../lib/context-generator');
 
-describe('operators', function(){
-
-  let context = generateContext();
+describe('operators', () => {
+  const context = generateContext();
   context.attributes.hasTreasure = true;
 
-  it('navigates based on a value', function(){
-    let sampleCondition = {
-      value: "attributes.hasTreasure",
+  it('navigates based on a value', () => {
+    const sampleCondition = {
+      value: 'attributes.hasTreasure',
       'if true': {
-        'go to': 'win' 
+        'go to': 'win',
       },
       'if false': {
-        'go to': 'lose'
-      }
-    }
+        'go to': 'lose',
+      },
+    };
     condition(sampleCondition, context);
     assert.equal(context.sessionAttributes.LABEL, 'win');
   });
-  
 });
-

--- a/test/eval-string.test.js
+++ b/test/eval-string.test.js
@@ -1,29 +1,27 @@
-'use strict';
+/* eslint no-template-curly-in-string:0 */
 
-const assert      = require('assert');
-const evalString  = require('../lib/eval-string');
+const assert = require('assert');
+const evalString = require('../lib/eval-string');
 
-describe('operators', function(){
-  let context = {
+describe('operators', () => {
+  const context = {
     attributes: {
-    }
+    },
   };
 
-  it('processes template strings', function(){
-    let evaluation = evalString('The result is ${1 + 2}.', context);
+  it('processes template strings', () => {
+    const evaluation = evalString('The result is ${1 + 2}.', context);
     assert.equal(evaluation, 'The result is 3.');
   });
 
-  it('replaces with empty strings when undefined/null/NaN are passed', function(){
-    let evaluation = evalString('This is a ${undefined} string.', context);
+  it('replaces with empty strings when undefined/null/NaN are passed', () => {
+    const evaluation = evalString('This is a ${undefined} string.', context);
     assert.equal(evaluation, 'This is a  string.');
   });
 
-  it('formats date strings to readable format', function(){
-    let evaluation = evalString('It is currently ${new Date()}', context);
-    let match      = evaluation.match(/\d{1,2} \d{1,2} [am|pm]{2} on [A-z]+ \d{1,2} \d{4}/) ? true : false;
+  it('formats date strings to readable format', () => {
+    const evaluation = evalString('It is currently ${new Date()}', context);
+    const match = !!evaluation.match(/\d{1,2} \d{1,2} [am|pm]{2} on [A-z]+ \d{1,2} \d{4}/);
     assert.equal(match, true);
-  })
-  
+  });
 });
-

--- a/test/expand-utterance.test.js
+++ b/test/expand-utterance.test.js
@@ -1,32 +1,27 @@
-'use strict';
+/* eslint max-len:0 */
 
-const assert       = require('assert');
+// const assert = require('assert');
 const expandUtterance = require('../lib/expand-utterance');
 
-describe('expand-utterance', function(){
+describe('expand-utterance', () => {
+  // const matcher = '(i would|i\'d) like [count:AMAZON.NUMBER] [snack:CustomType] [when:UnknownType]';
 
-  let matcher = '(i would|i\'d) like [count:AMAZON.NUMBER] [snack:CustomType] [when:UnknownType]';
+  const impliedTypeUtterance = 'look ma!  no [number] types!';
 
-  let impliedTypeUtterance = 'look ma!  no [number] types!';
-
-  let intent = {
+  const intent = {
     types: {
       CustomType: {
         values: [
           'apples',
           'oranges',
-          'peanuts'
-        ]
-      }
-    }
+          'peanuts',
+        ],
+      },
+    },
   };
 
-  it('guesses an implied built-in type', function(){
+  it('guesses an implied built-in type', () => {
     expandUtterance(impliedTypeUtterance, intent);
     // assert.deepEqual
   });
-  
 });
-
-
-

--- a/test/parse-xml.test.js
+++ b/test/parse-xml.test.js
@@ -1,25 +1,18 @@
-'use strict';
+const assert = require('assert');
+const parseXML = require('../lib/xml-parser');
 
-const assert          = require('assert');
-const parseXML        = require('../lib/xml-parser');
-
-describe('xml-parser', function(){
-
-  let xml = `
+describe('xml-parser', () => {
+  const xml = `
     <?xml version="1.0"?>
     <catalog>
        <book id="1">
           <title>Hello World</title>
        </book>
     </catalog>
-  `
+  `;
 
-  it('converts XML to an object', function(){
-    let obj = parseXML(xml);
+  it('converts XML to an object', () => {
+    const obj = parseXML(xml);
     assert.equal(obj.catalog.book[0].title[0], 'Hello World');
   });
-  
 });
-
-
-

--- a/test/pill-cutter.test.js
+++ b/test/pill-cutter.test.js
@@ -1,22 +1,19 @@
-'use strict';
+/* eslint no-prototype-builtins:0 */
 
-const assert          = require('assert');
-const cutPill         = require('../lib/pill-cutter');
+const assert = require('assert');
+const cutPill = require('../lib/pill-cutter');
 
-describe('speak', function(){
-
-  it('omits template objects', function(){
-    let pill = {
-      ".some-template" : {
-        speak: 'goodbye world'
+describe('speak', () => {
+  it('omits template objects', () => {
+    const pill = {
+      '.some-template': {
+        speak: 'goodbye world',
       },
       entrypoint: {
-        speak: 'hello world'
-      }
-    }
+        speak: 'hello world',
+      },
+    };
     cutPill(pill);
     assert.equal(pill.hasOwnProperty('.some-template'), false);
   });
-  
 });
-

--- a/test/speak.test.js
+++ b/test/speak.test.js
@@ -1,83 +1,78 @@
-'use strict';
-
-const assert          = require('assert');
-const speak           = require('../lib/builders/speak');
+const assert = require('assert');
+const speak = require('../lib/builders/speak');
 const generateContext = require('../lib/context-generator');
 
-describe('speak', function(){
-
-  it('takes a string', function(){
-    let context = generateContext();
+describe('speak', () => {
+  it('takes a string', () => {
+    const context = generateContext();
     speak('hello world', context);
     assert.equal(context.responseBody.outputSpeech.ssml, '<speak>hello world </speak>');
   });
 
-  it('takes a locale object and defaults to english', function(){
-    let context = generateContext();
-    speak({'en-US': 'hello world'}, context);
+  it('takes a locale object and defaults to english', () => {
+    const context = generateContext();
+    speak({ 'en-US': 'hello world' }, context);
     assert.equal(context.responseBody.outputSpeech.ssml, '<speak>hello world </speak>');
   });
 
-  it('selects the locale in the context', function(){
-    let context = generateContext();
+  it('selects the locale in the context', () => {
+    const context = generateContext();
     context.requestBody.locale = 'de-DE';
-    speak({'en-US': 'hello world', 'de-DE': 'hallo welt'}, context);
+    speak({ 'en-US': 'hello world', 'de-DE': 'hallo welt' }, context);
     assert.equal(context.responseBody.outputSpeech.ssml, '<speak>hallo welt </speak>');
   });
 
-  it('joins an array', function(){
-    let context = generateContext();
+  it('joins an array', () => {
+    const context = generateContext();
     speak(['bananas', 'oranges', 'apples'], context);
-    let didMatch = context.responseBody.outputSpeech.ssml.match(/apples|bananas|oranges/) ? true : false;
+    const didMatch = !!context.responseBody.outputSpeech.ssml.match(/apples|bananas|oranges/);
     assert.equal(didMatch, true);
   });
 
-  it('joins a locale array', function(){
-    let context = generateContext();
-    speak({'en-US': ['bananas', 'oranges', 'apples']}, context);
-    let didMatch = context.responseBody.outputSpeech.ssml.match(/apples|bananas|oranges/) ? true : false;
+  it('joins a locale array', () => {
+    const context = generateContext();
+    speak({ 'en-US': ['bananas', 'oranges', 'apples'] }, context);
+    const didMatch = !!context.responseBody.outputSpeech.ssml.match(/apples|bananas|oranges/);
     assert.equal(didMatch, true);
   });
 
-  it('picks random string from array', function(){
-    let context = generateContext();
-    speak({'en-US': {'random': ['bananas', 'oranges', 'apples']}}, context);
-    let didMatch = context.responseBody.outputSpeech.ssml.match(/apples|bananas|oranges/) ? true : false;
+  it('picks random string from array', () => {
+    const context = generateContext();
+    speak({ 'en-US': { random: ['bananas', 'oranges', 'apples'] } }, context);
+    const didMatch = !!context.responseBody.outputSpeech.ssml.match(/apples|bananas|oranges/);
     assert.equal(didMatch, true);
   });
 
-  it('inserts a break', function(){
-    let context = generateContext();
+  it('inserts a break', () => {
+    const context = generateContext();
     speak([
-      "hello",
-      {break: 'medium'},
-      "workd"
+      'hello',
+      { break: 'medium' },
+      'workd',
     ], context);
-    let didMatch = context.responseBody.outputSpeech.ssml.match(/<break strength="medium"\/>/) ? true : false;
+    const didMatch = !!context.responseBody.outputSpeech.ssml.match(/<break strength="medium"\/>/);
     assert.equal(didMatch, true);
   });
 
-  it('inserts a timed pause', function(){
-    let context = generateContext();
+  it('inserts a timed pause', () => {
+    const context = generateContext();
     speak([
-      "hello",
-      {pause: '2s'},
-      "workd"
+      'hello',
+      { pause: '2s' },
+      'workd',
     ], context);
-    let didMatch = context.responseBody.outputSpeech.ssml.match(/<break time="2s"\/>/) ? true : false;
+    const didMatch = !!context.responseBody.outputSpeech.ssml.match(/<break time="2s"\/>/);
     assert.equal(didMatch, true);
   });
 
-  it('inserts audio', function(){
-    let context = generateContext();
+  it('inserts audio', () => {
+    const context = generateContext();
     speak([
-      "hello",
-      {audio: 'http://test.audio'},
-      "workd"
+      'hello',
+      { audio: 'http://test.audio' },
+      'workd',
     ], context);
-    let didMatch = context.responseBody.outputSpeech.ssml.match(/<audio src="http:\/\/test.audio"\/>/) ? true : false;
+    const didMatch = !!context.responseBody.outputSpeech.ssml.match(/<audio src="http:\/\/test.audio"\/>/);
     assert.equal(didMatch, true);
   });
-  
 });
-


### PR DESCRIPTION
Hi
- Let's agree and set up linting. Since you started to use semicolons, `airbnb-base` is the first in line. Let's set up linting live, in the editor. I created `.eslintrc` which can by bypassed per-file.
- Tweaks for readme: badges, license, doctoc
- Tweaks for `package.json`, sorted, keywords, proper author and repo fields (npm didn't originally recognise GitHub repo!!!), new scripts, engines field

Feel free to edit or completely discard. The linting is not yet passing, I fixed only 75% of it.